### PR TITLE
Fix: DO-1798: Fix numeric input variable width

### DIFF
--- a/packages/ui-components/src/numeric-input/numeric-input.tsx
+++ b/packages/ui-components/src/numeric-input/numeric-input.tsx
@@ -85,6 +85,11 @@ const InputWrapper = styled.div<NumericInputProps>`
             background-color: ${(props) => (props.disabled ? props.theme.colors.grey1 : props.theme.colors.grey2)};
         }
     }
+
+    // Fix: Overrides the 22ch default width of the nested regular input
+    > div:first-child {
+        width: 100%;
+    }
 `;
 
 /**


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
The numeric input’s  `width: 22ch;` is applied twice. Once from the numeric input wrapper, and once from the regular input wrapper. This makes it impossible to change the input width using `Input(value=value, type='number', width='150px')`. 
This PR disables the second width rule to prevent it from overriding the width again.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
Works locally with and without the stepper.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
BEFORE:
![image](https://github.com/causalens/dara-ui/assets/119343173/726dfc0a-9aab-482c-b3a3-bef8f31c67c8)
AFTER:
![image](https://github.com/causalens/dara-ui/assets/119343173/0b27147e-a49d-4f95-b08e-4b4eabf281db)

