### PR TITLE
Fix: DO-1786 custsup datepicker doesnt show all available year choices

### DIFF
--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -4,7 +4,8 @@ title: Changelog
 
 ## NEXT
 
--   Fixed an issue where `Datepicker` in controlled mode would sometimes end up in an infinite loop
+-   Fixed an issue where `Datepicker` in controlled mode would sometimes end up in an infinite loop.
+-   Fixed an issue where `Datepicker` if range was given did not show end year in the select. 
 
 ## 1.0.1
 

--- a/packages/ui-components/src/datepicker/datepicker.tsx
+++ b/packages/ui-components/src/datepicker/datepicker.tsx
@@ -56,7 +56,7 @@ function getYears(minDate?: Date, maxDate?: Date): Item[] {
     const minYear = minDate?.getFullYear() ?? 1900;
     const maxYear = maxDate?.getFullYear() ?? 2100;
 
-    return range(minYear, maxYear, 1).map((val) => ({ label: val.toString(), value: val }));
+    return range(minYear, maxYear + 1, 1).map((val) => ({ label: val.toString(), value: val }));
 }
 
 /**


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
There was an issue for constrained `Datepicker` where the edge years would not show as options in the dropdown.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
When looking into it `lodash`'s `range` was being given the initial and end years. However in range the end bound is not included, therefore the fix was to add one to it.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On storybook and testing with the same range that the error was originally found

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->