### PR TITLE
Fix: DO-1833: Fix table header resizing

### DIFF
--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -6,6 +6,7 @@ title: Changelog
 
 -   Fixed an issue where `Datepicker` in controlled mode would sometimes end up in an infinite loop.
 -   Fixed an issue where `Datepicker` if range was given did not show end year in the select. 
+-   Fixed an issue where `Table` column resizing would not affect cell width.
 
 ## 1.0.1
 

--- a/packages/ui-components/src/table/render-row.tsx
+++ b/packages/ui-components/src/table/render-row.tsx
@@ -1,4 +1,3 @@
-import { some } from 'lodash';
 import { transparentize } from 'polished';
 import * as React from 'react';
 import { HeaderGroup } from 'react-table';
@@ -110,9 +109,29 @@ const CellContent = styled.span`
  * @param {any} nextProps - The next props.
  * @returns {boolean} - Whether the props are equal.
  */
-const arePropsEqual = (prevProps: any, nextProps: any): boolean =>
+const arePropsEqual = (prevProps: Props, nextProps: Props): boolean =>
     areEqual(prevProps, nextProps) &&
-    !some(nextProps.data?.headerGroups, (headerGroup) => some(headerGroup?.headers, 'isResizing'));
+    !(nextProps.data?.headerGroups || []).some((headerGroup) =>
+        (headerGroup?.headers || []).some((header) => header.isResizing)
+    );
+
+type Props = {
+    data: {
+        backgroundColor: string;
+        currentEditCell: [number, string | number];
+        getItem: (index: number) => any;
+        headerGroups: Array<HeaderGroup<object>>;
+        mappedColumns: Array<TableColumn>;
+        onClickRow: (row: any) => void | Promise<void>;
+        prepareRow: (row: any) => void;
+        rows: Array<any>;
+        throttledClickRow: (row: any) => void | Promise<void>;
+        totalColumnsWidth: number;
+        width: number;
+    };
+    index: number;
+    style: React.CSSProperties;
+};
 
 const RenderRow = React.memo(
     ({
@@ -131,23 +150,7 @@ const RenderRow = React.memo(
         },
         index,
         style: renderRowStyle,
-    }: {
-        data: {
-            backgroundColor: string;
-            currentEditCell: [number, string | number];
-            getItem: (index: number) => any;
-            headerGroups: Array<HeaderGroup<object>>;
-            mappedColumns: Array<TableColumn>;
-            onClickRow: (row: any) => void | Promise<void>;
-            prepareRow: (row: any) => void;
-            rows: Array<any>;
-            throttledClickRow: (row: any) => void | Promise<void>;
-            totalColumnsWidth: number;
-            width: number;
-        };
-        index: number;
-        style: React.CSSProperties;
-    }): JSX.Element => {
+    }: Props): JSX.Element => {
         let row = rows[index];
 
         if (getItem) {

--- a/packages/ui-components/src/table/render-row.tsx
+++ b/packages/ui-components/src/table/render-row.tsx
@@ -1,3 +1,4 @@
+import { some } from 'lodash';
 import { transparentize } from 'polished';
 import * as React from 'react';
 import { HeaderGroup } from 'react-table';
@@ -100,6 +101,18 @@ const CellContent = styled.span`
     text-overflow: ellipsis;
     white-space: nowrap;
 `;
+
+/**
+ * Checks if the previous and next props are equal while also
+ * forcing a re-render if any column in any headerGroup is being resized
+ *
+ * @param {any} prevProps - The previous props.
+ * @param {any} nextProps - The next props.
+ * @returns {boolean} - Whether the props are equal.
+ */
+const arePropsEqual = (prevProps: any, nextProps: any): boolean =>
+    areEqual(prevProps, nextProps) &&
+    !some(nextProps.data?.headerGroups, (headerGroup) => some(headerGroup?.headers, 'isResizing'));
 
 const RenderRow = React.memo(
     ({
@@ -235,7 +248,7 @@ const RenderRow = React.memo(
             </Row>
         );
     },
-    areEqual
+    arePropsEqual
 );
 
 export default RenderRow;


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
Caused by #9, the rows were memoized even after the resize event. It now forces a rerender when the user is resizing any column.

## Implementation Description
Overrides the `arePropsEqual` function to look specifically at each `headerGroup` and each header inside to check if the `isResizing` flag is set on any of them. This is equivalent in behavior to the one before #9.

## Any new dependencies Introduced
None

## How Has This Been Tested?
Storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->