### PR TITLE
Fix: DO-1900, DO-1914: Input width issues

### DIFF
--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -2,6 +2,15 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where `NumericInput` width could not be changed.
+-   Fixed an issue where `NumericInput` overflowed when hovered.
+-   Fixed an issue where `NumericInput` input did not take full space available to it.
+-   Fixed an issue where `Datepicker` could be overlapped by other components in a horizontal container.
+-   Fixed an issue where `Multiselect`'s input took too much space
+
+
 ## 1.1.0
 
 -   Fixed an issue where `Datepicker` in controlled mode would sometimes end up in an infinite loop.

--- a/packages/ui-components/src/datepicker/datepicker.tsx
+++ b/packages/ui-components/src/datepicker/datepicker.tsx
@@ -75,6 +75,9 @@ const DatepickerWrapper = styled.div<DatepickerWrapperProps>`
     display: flex;
     flex-direction: ${(props) => (props.inline ? 'column' : 'row')};
     align-items: ${(props) => (props.inline ? 'baseline' : 'center')};
+
+    width: 8.5rem;
+
     color: ${(props) => props.theme.colors.text};
 
     .react-datepicker-popper {

--- a/packages/ui-components/src/multiselect/multiselect.tsx
+++ b/packages/ui-components/src/multiselect/multiselect.tsx
@@ -377,6 +377,7 @@ function MultiSelect({ maxWidth = '100%', maxRows = 3, ...props }: MultiSelectPr
                             onFocus={openMenu}
                             placeholder={props.placeholder}
                             size={props.size}
+                            style={{ flex: '1 1 5ch' }}
                         />
                     </TagWrapper>
                     <ChevronButton {...getToggleButtonProps()}>

--- a/packages/ui-components/src/numeric-input/numeric-input.tsx
+++ b/packages/ui-components/src/numeric-input/numeric-input.tsx
@@ -57,7 +57,6 @@ const InputWrapper = styled.div<NumericInputProps>`
     }
 
     input {
-        width: calc(100% - 1.25rem);
         height: calc(2.5rem - 2px);
         border: none;
         border-radius: 0.25rem;
@@ -97,6 +96,7 @@ const InputWrapper = styled.div<NumericInputProps>`
     // Fix: Overrides the 22ch default width of the nested regular input
     > div:first-child {
         width: 100%;
+        height: auto;
     }
 `;
 
@@ -256,7 +256,12 @@ const NumericInput = React.forwardRef<HTMLInputElement, NumericInputProps>(
 
         return (
             <div>
-                <InputWrapper disabled={props.disabled} errorMsg={props.errorMsg} stepper={props.stepper}>
+                <InputWrapper
+                    disabled={props.disabled}
+                    errorMsg={props.errorMsg}
+                    stepper={props.stepper}
+                    style={props.style}
+                >
                     <Input
                         autoFocus={props.autoFocus}
                         className={props.className}
@@ -270,7 +275,6 @@ const NumericInput = React.forwardRef<HTMLInputElement, NumericInputProps>(
                         onKeyDown={onKeyDown}
                         placeholder={props.placeholder}
                         ref={ref}
-                        style={props.style}
                         value={input}
                     />
                     {props.stepper && <InputStepper disabled={props.disabled} step={step} stepSkip={props.stepSkip} />}


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
A number of small issues relating to the width of input components were found:
- Datepicker would overlap with one another
- User could not easily set the width to a numeric input
- Multiselect input was taking too much space
This PR addresses these issues

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
The `Datepicker` issue was found due to the outer wrapper essentially thinking that its width was 0, I believe this is due the popper, the fix was simply to add a width equal to the input size.
When testing `NumericInput` a second issue was found that on hover the input box moved a pixel downwards due to the border effect. The fix was to add an auto height to the inner input.
It was also found that the input width was too narrow, this became more apparent when the whole component's width became smaller, I removed the previous restriction of width, which given the current paddings is not needed.
The width was not able to be set on the Dara side because the style was one component inwards than it should have been, this was also addressed.
Finally on Dara the `Multiselect`'s width took more space than it should and in some cases resulted in an unnecessary next line added to the component. The fix here was to set flex-basis to a reasonable number, in this instance I set it to '5ch'.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Datepicker and NumericInput were tested on Storybook.
Multiselect issue, I could not recreate it on Storybook, this always seemed to behave as expected. Instead I tested these changes on an app running in Dara instead. I then tested on Storybook for further variations after the fix was made. 

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [ ] I have implemented all requirements? (see JIRA, project documentation).
- [ ] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
Before:
<img width="564" alt="Screenshot 2023-10-11 at 13 42 24" src="https://github.com/causalens/dara-ui/assets/104359539/1f2fb878-8d6c-40f5-9114-1e2d27411c56">
<img width="759" alt="Screenshot Oct 3" src="https://github.com/causalens/dara-ui/assets/104359539/ba3e1e63-1ac3-44ce-a788-36e0be2e3739">
After:
<img width="564" alt="Screenshot 2023-10-11 at 13 42 54" src="https://github.com/causalens/dara-ui/assets/104359539/752aca9d-535c-4cc5-89dd-dad45079f9fb">
<img width="82" alt="Screenshot 2023-10-11 at 13 58 33" src="https://github.com/causalens/dara-ui/assets/104359539/f0cc6c33-c1cc-48ca-923f-11f23a3a4d3e">
<img width="314" alt="Screenshot 2023-10-11 at 13 57 59" src="https://github.com/causalens/dara-ui/assets/104359539/5439134f-b0db-4fca-9285-889a93f931b7">
