### PR TITLE
Fix: DO-2086 update edge constraints in visual edge encoder

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Updated `EdgeConstraintType` to comply to `0.3.0` of `cai-causal-graph`.
+
 ## 1.2.2
 
 -   Updated serializers to support setting metadata in extra attributes.

--- a/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
@@ -663,7 +663,7 @@ VisualEdgeEncoder.args = {
         {
             source: 'first node',
             target: 'second node',
-            type: EdgeConstraintType.DIRECTED,
+            type: EdgeConstraintType.HARD_DIRECTED,
         },
     ],
 };

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/sections/constraint-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/sections/constraint-editor.tsx
@@ -51,16 +51,6 @@ const constraintItems: IconItem[] = [
     },
     {
         label: (
-            <Tooltip content="Directed">
-                <span>
-                    <ArrowRightLong size="lg" />
-                </span>
-            </Tooltip>
-        ),
-        value: EdgeConstraintType.SOFT_DIRECTED,
-    },
-    {
-        label: (
             <Tooltip content="Forbidden">
                 <span>
                     <Ban size="lg" />

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/sections/constraint-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/sections/constraint-editor.tsx
@@ -14,10 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { EdgeConstraintItem, EdgeConstraintType } from '@types';
 
 import { ButtonBar, Item, Tooltip } from '@darajs/ui-components';
 import { ArrowRightLong, ArrowsHorizontal, Ban } from '@darajs/ui-icons';
+
+import { EdgeConstraintItem, EdgeConstraintType } from '@types';
 
 import { ColumnWrapper, SectionTitle } from '../../styled';
 

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/sections/constraint-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/sections/constraint-editor.tsx
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { EdgeConstraintItem, EdgeConstraintType } from '@types';
+
 import { ButtonBar, Item, Tooltip } from '@darajs/ui-components';
 import { ArrowRightLong, ArrowsHorizontal, Ban } from '@darajs/ui-icons';
-
-import { EdgeConstraintItem, EdgeConstraintType } from '@types';
 
 import { ColumnWrapper, SectionTitle } from '../../styled';
 
@@ -47,7 +47,17 @@ const constraintItems: IconItem[] = [
                 </span>
             </Tooltip>
         ),
-        value: EdgeConstraintType.DIRECTED,
+        value: EdgeConstraintType.HARD_DIRECTED,
+    },
+    {
+        label: (
+            <Tooltip content="Directed">
+                <span>
+                    <ArrowRightLong size="lg" />
+                </span>
+            </Tooltip>
+        ),
+        value: EdgeConstraintType.SOFT_DIRECTED,
     },
     {
         label: (

--- a/packages/ui-causal-graph-editor/src/shared/rendering/edge/symbols.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/edge/symbols.tsx
@@ -55,7 +55,10 @@ export function createSideSymbol(
 
         if (style.editorMode === EditorMode.EDGE_ENCODER) {
             // Encoder - only show arrow for directed constraint
-            if (style.constraint?.type !== EdgeConstraintType.DIRECTED) {
+            if (
+                style.constraint?.type !== EdgeConstraintType.HARD_DIRECTED &&
+                style.constraint?.type !== EdgeConstraintType.SOFT_DIRECTED
+            ) {
                 return gfx;
             }
         }

--- a/packages/ui-causal-graph-editor/src/shared/use-edge-encoder.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-edge-encoder.tsx
@@ -32,7 +32,8 @@ export function parseConstraints(constraints: EdgeConstraint[]): EdgeConstraintI
 
         switch (constraintType) {
             // These are handled fine, leave as-is
-            case EdgeConstraintType.DIRECTED:
+            case EdgeConstraintType.HARD_DIRECTED:
+            case EdgeConstraintType.SOFT_DIRECTED:
             case EdgeConstraintType.FORBIDDEN:
             case EdgeConstraintType.UNDIRECTED:
                 break;

--- a/packages/ui-causal-graph-editor/src/types.tsx
+++ b/packages/ui-causal-graph-editor/src/types.tsx
@@ -203,11 +203,10 @@ export type SimulationGraph = AbstractGraph<SimulationNode, SimulationEdge, Simu
  * Int values from cl_interfaces.EdgeConstraint
  */
 export enum EdgeConstraintType {
-    DIRECTED = 2,
-    /** Backward directed - unsupported */
-    BACKWARD_DIRECTED = 3,
-    FORBIDDEN = 4,
-    UNDIRECTED = 1,
+    FORBIDDEN = 'forbidden',
+    HARD_DIRECTED = 'hard_directed',
+    SOFT_DIRECTED = 'soft_directed',
+    UNDIRECTED = 'hard_undirected',
 }
 
 /**

--- a/packages/ui-causal-graph-editor/src/types.tsx
+++ b/packages/ui-causal-graph-editor/src/types.tsx
@@ -200,7 +200,7 @@ export type SimulationGraph = AbstractGraph<SimulationNode, SimulationEdge, Simu
 /**
  * Type of an edge constraint that can be encoded
  *
- * Int values from cl_interfaces.EdgeConstraint
+ * str values from cai_causal_graph.EdgeConstraint
  */
 export enum EdgeConstraintType {
     FORBIDDEN = 'forbidden',


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
With release of 0.3.0 of `cai-causal-graph` there have been changes to how constraint edges are defined:
https://github.com/causalens/cai-causal-graph/commit/e47ee4357fc5ec8291c3d548438b4f4fbea1170f

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Update `EdgeConstraintType` to have the same values as the newly defined. At the moment I have made so that SOFT_DIRECTED and HARD_DIRECTED will behave and look in the same way. We can later add different visual representations for them once we have an idea for what this should be. 

There will be accompanying PRs across dara, and ui internal, dara internal adapting to these changes.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on Storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->