### PR TITLE
Feat: DO-2140: Support edge source/destination attributes for CausalGraphEditor

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Added support for edge `source`/`destination` fields for `CausalGraphEditor`.
+
 ## 1.3.0
 
 -   Updated `EdgeConstraintType` to comply to `0.3.0` of `cai-causal-graph`.

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -14,17 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import debounce from 'lodash/debounce';
-import noop from 'lodash/noop';
-import { useEffect, useMemo, useState } from 'react';
-import * as React from 'react';
-import { GetReferenceClientRect } from 'tippy.js';
-
-import { useTheme } from '@darajs/styled-components';
-import { Tooltip } from '@darajs/ui-components';
-import { Status, useUpdateEffect } from '@darajs/ui-utils';
-import { ConfirmationModal } from '@darajs/ui-widgets';
-
 import {
     AddNodeButton,
     CenterGraphButton,
@@ -50,6 +39,16 @@ import {
     SimulationEdge,
     ZoomThresholds,
 } from '@types';
+import debounce from 'lodash/debounce';
+import noop from 'lodash/noop';
+import { useEffect, useMemo, useState } from 'react';
+import * as React from 'react';
+import { GetReferenceClientRect } from 'tippy.js';
+
+import { useTheme } from '@darajs/styled-components';
+import { Tooltip } from '@darajs/ui-components';
+import { Status, useUpdateEffect } from '@darajs/ui-utils';
+import { ConfirmationModal } from '@darajs/ui-widgets';
 
 import GraphContext from '../shared/graph-context';
 import { GraphLayout } from '../shared/graph-layout';
@@ -168,7 +167,7 @@ function CausalGraphEditor(props: CausalGraphEditorProps): JSX.Element {
             let serializedNode: CausalGraphNode = null;
 
             if (selectedNode) {
-                serializedNode = serializeGraphNode(state.graph.getNodeAttributes(selectedNode), true);
+                serializedNode = serializeGraphNode(state.graph.getNodeAttributes(selectedNode));
             }
 
             props.onClickNode(serializedNode);
@@ -188,8 +187,8 @@ function CausalGraphEditor(props: CausalGraphEditorProps): JSX.Element {
                 const [source, target] = selectedEdge;
                 serializedEdge = serializeGraphEdge(
                     state.graph.getEdgeAttributes(source, target),
-                    serializeGraphNode(state.graph.getNodeAttributes(source), true),
-                    serializeGraphNode(state.graph.getNodeAttributes(target), true)
+                    serializeGraphNode(state.graph.getNodeAttributes(source)),
+                    serializeGraphNode(state.graph.getNodeAttributes(target))
                 );
             }
 

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -14,6 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import debounce from 'lodash/debounce';
+import noop from 'lodash/noop';
+import { useEffect, useMemo, useState } from 'react';
+import * as React from 'react';
+import { GetReferenceClientRect } from 'tippy.js';
+
+import { useTheme } from '@darajs/styled-components';
+import { Tooltip } from '@darajs/ui-components';
+import { Status, useUpdateEffect } from '@darajs/ui-utils';
+import { ConfirmationModal } from '@darajs/ui-widgets';
+
 import {
     AddNodeButton,
     CenterGraphButton,
@@ -39,16 +50,6 @@ import {
     SimulationEdge,
     ZoomThresholds,
 } from '@types';
-import debounce from 'lodash/debounce';
-import noop from 'lodash/noop';
-import { useEffect, useMemo, useState } from 'react';
-import * as React from 'react';
-import { GetReferenceClientRect } from 'tippy.js';
-
-import { useTheme } from '@darajs/styled-components';
-import { Tooltip } from '@darajs/ui-components';
-import { Status, useUpdateEffect } from '@darajs/ui-utils';
-import { ConfirmationModal } from '@darajs/ui-widgets';
 
 import GraphContext from '../shared/graph-context';
 import { GraphLayout } from '../shared/graph-layout';

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -186,7 +186,11 @@ function CausalGraphEditor(props: CausalGraphEditorProps): JSX.Element {
 
             if (selectedEdge) {
                 const [source, target] = selectedEdge;
-                serializedEdge = serializeGraphEdge(state.graph.getEdgeAttributes(source, target), source, target);
+                serializedEdge = serializeGraphEdge(
+                    state.graph.getEdgeAttributes(source, target),
+                    serializeGraphNode(state.graph.getNodeAttributes(source), true),
+                    serializeGraphNode(state.graph.getNodeAttributes(target), true)
+                );
             }
 
             props.onClickEdge(serializedEdge);

--- a/packages/ui-causal-graph-editor/src/shared/serializer.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/serializer.tsx
@@ -49,7 +49,11 @@ function removeNodePrefix<T extends keyof FlatNodeRenderingMeta>(key: T): keyof 
  * @param source optional source to include in output data
  * @param destination optional destination to include in output data
  */
-export function serializeGraphEdge(attributes: SimulationEdge, source?: CausalGraphNode, destination?: CausalGraphNode): CausalGraphEdge {
+export function serializeGraphEdge(
+    attributes: SimulationEdge,
+    source?: CausalGraphNode,
+    destination?: CausalGraphNode
+): CausalGraphEdge {
     const entries = Object.entries(attributes) as Entries<SimulationEdge>;
     const unflattenedMeta: EdgeRenderingMeta = Object.fromEntries(
         entries

--- a/packages/ui-causal-graph-editor/src/shared/serializer.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/serializer.tsx
@@ -100,7 +100,7 @@ export function serializeGraphEdge(
  * @param attributes simulation node data
  * @param includeIdentifier whether to include data to identify the node
  */
-export function serializeGraphNode(attributes: SimulationNode, includeIdentifier = false): CausalGraphNode {
+export function serializeGraphNode(attributes: SimulationNode): CausalGraphNode {
     const entries = Object.entries(attributes) as Entries<SimulationNode>;
     const unflattenedMeta: NodeRenderingMeta = Object.fromEntries(
         entries
@@ -120,11 +120,8 @@ export function serializeGraphNode(attributes: SimulationNode, includeIdentifier
         },
         variable_type: attributes.variable_type,
         ...restExtras,
+        identifier: attributes.id,
     };
-
-    if (includeIdentifier) {
-        output.identifier = attributes.id;
-    }
 
     return output;
 }
@@ -161,6 +158,7 @@ export function causalGraphSerializer(state: GraphState): CausalGraph {
                 },
                 variable_type: attributes.variable_type,
                 ...restExtras,
+                identifier: attributes.id,
             };
 
             return acc;

--- a/packages/ui-causal-graph-editor/src/shared/serializer.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/serializer.tsx
@@ -51,8 +51,8 @@ function removeNodePrefix<T extends keyof FlatNodeRenderingMeta>(key: T): keyof 
  */
 export function serializeGraphEdge(
     attributes: SimulationEdge,
-    source?: CausalGraphNode,
-    destination?: CausalGraphNode
+    source: CausalGraphNode,
+    destination: CausalGraphNode
 ): CausalGraphEdge {
     const entries = Object.entries(attributes) as Entries<SimulationEdge>;
     const unflattenedMeta: EdgeRenderingMeta = Object.fromEntries(
@@ -183,6 +183,9 @@ export function causalGraphSerializer(state: GraphState): CausalGraph {
                 if (!(target in acc)) {
                     acc[target] = {};
                 }
+                const temp = serializedEdge.destination;
+                serializedEdge.destination = serializedEdge.source;
+                serializedEdge.source = temp;
                 acc[target][source] = serializedEdge;
             } else {
                 if (!(source in acc)) {

--- a/packages/ui-causal-graph-editor/src/shared/serializer.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/serializer.tsx
@@ -74,15 +74,9 @@ export function serializeGraphEdge(
             rendering_properties: unflattenedMeta,
         },
         ...restExtras,
+        destination,
+        source,
     };
-
-    if (source) {
-        output.source = source;
-    }
-
-    if (destination) {
-        output.destination = destination;
-    }
 
     // Reverse the edge if it is a backwards directed edge
     if (output.edge_type === EdgeType.BACKWARDS_DIRECTED_EDGE) {

--- a/packages/ui-causal-graph-editor/src/types.tsx
+++ b/packages/ui-causal-graph-editor/src/types.tsx
@@ -103,11 +103,11 @@ export interface CausalGraphNode {
 }
 
 export interface CausalGraphEdge {
-    destination?: CausalGraphNode;
+    destination: CausalGraphNode;
     edge_type: EdgeType;
     extras?: Record<string, any>;
     meta: CausalGraphEdgeMeta;
-    source?: CausalGraphNode;
+    source: CausalGraphNode;
 }
 
 export enum VariableType {

--- a/packages/ui-causal-graph-editor/src/types.tsx
+++ b/packages/ui-causal-graph-editor/src/types.tsx
@@ -98,15 +98,16 @@ export interface CausalGraphNode {
     extras?: Record<string, any>;
     identifier?: string;
     meta: CausalGraphNodeMeta;
+    node_class?: string;
     variable_type: string;
 }
 
 export interface CausalGraphEdge {
-    destination?: string;
+    destination?: CausalGraphNode;
     edge_type: EdgeType;
     extras?: Record<string, any>;
     meta: CausalGraphEdgeMeta;
-    source?: string;
+    source?: CausalGraphNode;
 }
 
 export enum VariableType {

--- a/packages/ui-causal-graph-editor/src/types.tsx
+++ b/packages/ui-causal-graph-editor/src/types.tsx
@@ -96,7 +96,7 @@ export interface CausalGraph {
 
 export interface CausalGraphNode {
     extras?: Record<string, any>;
-    identifier?: string;
+    identifier: string;
     meta: CausalGraphNodeMeta;
     node_class?: string;
     variable_type: string;

--- a/packages/ui-causal-graph-editor/tests/causal-graph-parser.spec.tsx
+++ b/packages/ui-causal-graph-editor/tests/causal-graph-parser.spec.tsx
@@ -25,9 +25,15 @@ describe('CausalGraphParser', () => {
 
             if (expectedEdge.edge_type === EdgeType.BACKWARDS_DIRECTED_EDGE) {
                 expectedEdge.edge_type = EdgeType.DIRECTED_EDGE;
+                // Flip backwards edge source/destination
+                const temp = expectedEdge.destination;
+                expectedEdge.destination = expectedEdge.source;
+                expectedEdge.source = temp;
             }
 
-            expect(serializeGraphEdge(attrs)).toEqual(expectedEdge);
+            expect(serializeGraphEdge(attrs, MockCausalGraph.nodes[source], MockCausalGraph.nodes[target])).toEqual(
+                expectedEdge
+            );
         });
 
         parsedGraph.forEachNode((id, attrs) => {

--- a/packages/ui-causal-graph-editor/tests/causal-graph-parser.spec.tsx
+++ b/packages/ui-causal-graph-editor/tests/causal-graph-parser.spec.tsx
@@ -45,7 +45,7 @@ describe('CausalGraphParser', () => {
             // No available inputs provided - all nodes are not latent
             expectedNode.meta.rendering_properties.latent = false;
 
-            expect(serializeGraphNode(attrs, true)).toEqual(expectedNode);
+            expect(serializeGraphNode(attrs)).toEqual(expectedNode);
         });
     });
 

--- a/packages/ui-causal-graph-editor/tests/causal-graph-parser.spec.tsx
+++ b/packages/ui-causal-graph-editor/tests/causal-graph-parser.spec.tsx
@@ -45,7 +45,7 @@ describe('CausalGraphParser', () => {
             // No available inputs provided - all nodes are not latent
             expectedNode.meta.rendering_properties.latent = false;
 
-            expect(serializeGraphNode(attrs)).toEqual(expectedNode);
+            expect(serializeGraphNode(attrs, true)).toEqual(expectedNode);
         });
     });
 
@@ -58,6 +58,7 @@ describe('CausalGraphParser', () => {
         for (const node of parsedGraph.nodes()) {
             expect(parsedGraph.getNodeAttributes(node).extras).toEqual({
                 erased: nodes[node].erased,
+                identifier: nodes[node].identifier,
                 redacted: nodes[node].redacted,
             });
         }
@@ -74,7 +75,9 @@ describe('CausalGraphParser', () => {
             const { erased } = edgeAttributes[targetNode];
 
             expect(parsedGraph.getEdgeAttributes(edge).extras).toEqual({
+                destination: edgeAttributes[targetNode].destination,
                 erased,
+                source: edgeAttributes[targetNode].source,
             });
         });
 

--- a/packages/ui-causal-graph-editor/tests/causal-graph-serializer.spec.tsx
+++ b/packages/ui-causal-graph-editor/tests/causal-graph-serializer.spec.tsx
@@ -60,8 +60,6 @@ describe('CausalGraphSerializer', () => {
         expectedEdges.target1.input2 = expectedEdges.input2.target1;
         delete expectedEdges.input2.target1;
         expectedEdges.target1.input2.edge_type = EdgeType.DIRECTED_EDGE;
-        expectedEdges.target1.input2.source = expectedNodes.target1;
-        expectedEdges.target1.input2.destination = expectedNodes.input2;
 
         expect(causalGraphSerializer({ graph: parsedGraph })).toEqual({
             edges: expectedEdges,

--- a/packages/ui-causal-graph-editor/tests/causal-graph-store.spec.tsx
+++ b/packages/ui-causal-graph-editor/tests/causal-graph-store.spec.tsx
@@ -1,7 +1,6 @@
 import Graph from 'graphology';
 
 import { GraphActionCreators, GraphReducer } from '../src/shared/causal-graph-store';
-import { causalGraphSerializer } from '../src/shared/serializer';
 import { EdgeType, EditorMode, GraphState, SimulationEdge, SimulationNode, VariableType } from '../src/types';
 
 const DEFAULT_EDGE: SimulationEdge = { edge_type: EdgeType.DIRECTED_EDGE, originalMeta: {} };

--- a/packages/ui-causal-graph-editor/tests/mocks/extras-graph.tsx
+++ b/packages/ui-causal-graph-editor/tests/mocks/extras-graph.tsx
@@ -1,14 +1,30 @@
 const MockCausalGraphWithExtras = {
     defaults: { edge_activation: null, node_activation: null, node_redacted: null },
     edges: {
-        A: { B: { edge_type: '->', erased: ['piecewise_linear', 'piecewise_linear_decreasing'], meta: {} } },
-        B: { C: { edge_type: '->', erased: ['linear'], meta: {} } },
+        A: {
+            B: {
+                destination: { erased: null, identifier: 'B', meta: {}, redacted: null, variable_type: 'unspecified' },
+                edge_type: '->',
+                erased: ['piecewise_linear', 'piecewise_linear_decreasing'],
+                meta: {},
+                source: { erased: null, identifier: 'A', meta: {}, redacted: null, variable_type: 'unspecified' },
+            },
+        },
+        B: {
+            C: {
+                destination: { erased: null, identifier: 'C', meta: {}, redacted: null, variable_type: 'unspecified' },
+                edge_type: '->',
+                erased: ['linear'],
+                meta: {},
+                source: { erased: null, identifier: 'B', meta: {}, redacted: null, variable_type: 'unspecified' },
+            },
+        },
     },
     nodes: {
-        A: { erased: null, meta: {}, redacted: null, variable_type: 'unspecified' },
-        B: { erased: null, meta: {}, redacted: null, variable_type: 'unspecified' },
-        C: { erased: null, meta: {}, redacted: null, variable_type: 'unspecified' },
-        D: { erased: null, meta: {}, redacted: 'sum', variable_type: 'unspecified' },
+        A: { erased: null, identifier: 'A', meta: {}, redacted: null, variable_type: 'unspecified' },
+        B: { erased: null, identifier: 'B', meta: {}, redacted: null, variable_type: 'unspecified' },
+        C: { erased: null, identifier: 'C', meta: {}, redacted: null, variable_type: 'unspecified' },
+        D: { erased: null, identifier: 'D', meta: {}, redacted: 'sum', variable_type: 'unspecified' },
     },
     version: '0.8.0',
 };

--- a/packages/ui-causal-graph-editor/tests/utils.tsx
+++ b/packages/ui-causal-graph-editor/tests/utils.tsx
@@ -3,36 +3,109 @@ import { CausalGraph, EdgeType, VariableType } from '../src/types';
 export const MockCausalGraph: CausalGraph = {
     edges: {
         input1: {
-            target1: { edge_type: EdgeType.DIRECTED_EDGE, meta: {} },
+            target1: {
+                destination: {
+                    identifier: 'target1',
+                    meta: { rendering_properties: { label_size: 25, size: 60 } },
+                    node_class: 'Node',
+                    variable_type: VariableType.UNSPECIFIED,
+                },
+                edge_type: EdgeType.DIRECTED_EDGE,
+                meta: {},
+                source: {
+                    identifier: 'input1',
+                    meta: {
+                        original: 'metadata',
+                        rendering_properties: {
+                            label: 'input1 label',
+                        },
+                    },
+                    node_class: 'Node',
+                    variable_type: VariableType.UNSPECIFIED,
+                },
+            },
             target2: {
+                destination: {
+                    identifier: 'target2',
+                    meta: {},
+                    node_class: 'Node',
+                    variable_type: VariableType.UNSPECIFIED,
+                },
                 edge_type: EdgeType.DIRECTED_EDGE,
                 meta: { original: 'metadata', rendering_properties: { color: '#7510F7', thickness: 10 } },
+                source: {
+                    identifier: 'input1',
+                    meta: {
+                        original: 'metadata',
+                        rendering_properties: {
+                            label: 'input1 label',
+                        },
+                    },
+                    node_class: 'Node',
+                    variable_type: VariableType.UNSPECIFIED,
+                },
             },
         },
         input2: {
-            target1: { edge_type: EdgeType.BACKWARDS_DIRECTED_EDGE, meta: {} },
-            target2: { edge_type: EdgeType.DIRECTED_EDGE, meta: {} },
+            target1: {
+                destination: {
+                    identifier: 'target1',
+                    meta: { rendering_properties: { label_size: 25, size: 60 } },
+                    node_class: 'Node',
+                    variable_type: VariableType.UNSPECIFIED,
+                },
+                edge_type: EdgeType.BACKWARDS_DIRECTED_EDGE,
+                meta: {},
+                source: {
+                    identifier: 'input2',
+                    meta: {},
+                    node_class: 'Node',
+                    variable_type: VariableType.UNSPECIFIED,
+                },
+            },
+            target2: {
+                destination: {
+                    identifier: 'target2',
+                    meta: {},
+                    node_class: 'Node',
+                    variable_type: VariableType.UNSPECIFIED,
+                },
+                edge_type: EdgeType.DIRECTED_EDGE,
+                meta: {},
+                source: {
+                    identifier: 'input2',
+                    meta: {},
+                    node_class: 'Node',
+                    variable_type: VariableType.UNSPECIFIED,
+                },
+            },
         },
     },
     nodes: {
         input1: {
+            identifier: 'input1',
             meta: {
                 original: 'metadata',
                 rendering_properties: {
                     label: 'input1 label',
                 },
             },
+            node_class: 'Node',
             variable_type: VariableType.UNSPECIFIED,
         },
         input2: {
+            identifier: 'input2',
             meta: {},
+            node_class: 'Node',
             variable_type: VariableType.UNSPECIFIED,
         },
         target1: {
+            identifier: 'target1',
             meta: { rendering_properties: { label_size: 25, size: 60 } },
+            node_class: 'Node',
             variable_type: VariableType.UNSPECIFIED,
         },
-        target2: { meta: {}, variable_type: VariableType.UNSPECIFIED },
+        target2: { identifier: 'target2', meta: {}, node_class: 'Node', variable_type: VariableType.UNSPECIFIED },
     },
     version: '2',
 };


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
`CausalGraph`'s edge `source`/`destination` fields are no longer strings, but objects containing a copy of the node info. Additionally, each node now has a `node_class` field.

## Implementation Description
Modifies `serializeGraphEdge` to include the node info. Since `onClickEdge` callback also uses it, its signature was updated to return a node object instead of a string as well.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
Tests were updated accordingly. The mock causal graph now includes source/destination fields.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->