### PR TITLE
Fix: DO-2267 DO-2281 drag nodes not working correctly

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,9 +2,13 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fix an issue where dragging nodes too quickly would cause the node drag to stop working
+
 ## 1.4.0
 
--   Added a differentiated arrow for `EdgeConstraintType.SOFT_DIRECTED` 
+-   Added a differentiated arrow for `EdgeConstraintType.SOFT_DIRECTED`
 -   Added support for edge `source`/`destination` fields for `CausalGraphEditor`.
 
 ## 1.3.0
@@ -18,7 +22,7 @@ title: Changelog
 
 ## 1.2.0
 
--   Updated so that graph object can take extra fields in its object, and `edgeExtrasContent` was added to the editor to allow extras fields to be added to side panel. 
+-   Updated so that graph object can take extra fields in its object, and `edgeExtrasContent` was added to the editor to allow extras fields to be added to side panel.
 
 ## 1.0.0
 

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -694,7 +694,9 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
                 this.emit('nodeMouseout', event, id);
             }
 
-            if (!this.editable) {
+            // don't reset mousedownKey if we're dragging as this can prevent the drag
+            // from working correctly when dragging quickly outside of a node
+            if (!this.editable && !this.isMovingNode && !this.isCreatingEdge) {
                 // resets mousedown position
                 this.mousedownNodeKey = null;
             }


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

This PR fixes an issue where dragging would not work correctly when moving the mouse too quickly, particularly in non-editable mode. 
To reproduce previously:
- run graph in non-editable mode with a layout which allows node drag (e.g. fCoSE)
- attempt to drag a node - moving mouse quickly works, but if the cursor ends up outside of the node the dragging breaks rather than adjusting the node position further


https://github.com/causalens/dara-ui/assets/87647189/77530aac-43ac-4054-a8f5-24fb6cb163d6

The issue was due to the `mousedownNodeKey` (variable holding which node was originally pressed at the start of drag) being reset on `mouseout`, even while dragging. The regression was traced back to PR 275 in the old (closed source) repo. 

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Fixed by adding a guard to only reset the mouse down node key if not currently dragging.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually.
As this area is not covered by automatic tests I'd appreciate if reviewers could verify the fix as well.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
After fix:

https://github.com/causalens/dara-ui/assets/87647189/be8ba96d-3fc2-4673-8e8e-db9f3dc89b25


