### PR TITLE
Feat: DO-1586 custsup causal graph viewer allow for both storing the clicked node and clicked edge

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Added `simultaneousEdgeNodeSelection` prop to `CausalGraphEditor` which when set to true allows for both an edge and a node to be selected simultaneously. 
+
 ## 1.5.0
 
 -   Added support for tiered layout in `Fcose`, `Planar`, `Spring` and `Marketing` layouts. It allows for nodes to be placed on tiers following some hierarchy and to further define requirements of nodes positions within that tier.

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -14,6 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import debounce from 'lodash/debounce';
+import noop from 'lodash/noop';
+import { useEffect, useMemo, useState } from 'react';
+import * as React from 'react';
+import { GetReferenceClientRect } from 'tippy.js';
+
+import styled, { useTheme } from '@darajs/styled-components';
+import { Tooltip } from '@darajs/ui-components';
+import { Notification, NotificationPayload } from '@darajs/ui-notifications';
+import { Status, useUpdateEffect } from '@darajs/ui-utils';
+import { ConfirmationModal } from '@darajs/ui-widgets';
+
 import {
     AddNodeButton,
     CenterGraphButton,
@@ -39,17 +51,6 @@ import {
     SimulationEdge,
     ZoomThresholds,
 } from '@types';
-import debounce from 'lodash/debounce';
-import noop from 'lodash/noop';
-import { useEffect, useMemo, useState } from 'react';
-import * as React from 'react';
-import { GetReferenceClientRect } from 'tippy.js';
-
-import styled, { useTheme } from '@darajs/styled-components';
-import { Tooltip } from '@darajs/ui-components';
-import { Notification, NotificationPayload } from '@darajs/ui-notifications';
-import { Status, useUpdateEffect } from '@darajs/ui-utils';
-import { ConfirmationModal } from '@darajs/ui-widgets';
 
 import GraphContext from '../shared/graph-context';
 import { GraphLayout } from '../shared/graph-layout';

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -14,18 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import debounce from 'lodash/debounce';
-import noop from 'lodash/noop';
-import { useEffect, useMemo, useState } from 'react';
-import * as React from 'react';
-import { GetReferenceClientRect } from 'tippy.js';
-
-import styled, { useTheme } from '@darajs/styled-components';
-import { Tooltip } from '@darajs/ui-components';
-import { Notification, NotificationPayload } from '@darajs/ui-notifications';
-import { Status, useUpdateEffect } from '@darajs/ui-utils';
-import { ConfirmationModal } from '@darajs/ui-widgets';
-
 import {
     AddNodeButton,
     CenterGraphButton,
@@ -51,6 +39,17 @@ import {
     SimulationEdge,
     ZoomThresholds,
 } from '@types';
+import debounce from 'lodash/debounce';
+import noop from 'lodash/noop';
+import { useEffect, useMemo, useState } from 'react';
+import * as React from 'react';
+import { GetReferenceClientRect } from 'tippy.js';
+
+import styled, { useTheme } from '@darajs/styled-components';
+import { Tooltip } from '@darajs/ui-components';
+import { Notification, NotificationPayload } from '@darajs/ui-notifications';
+import { Status, useUpdateEffect } from '@darajs/ui-utils';
+import { ConfirmationModal } from '@darajs/ui-widgets';
 
 import GraphContext from '../shared/graph-context';
 import { GraphLayout } from '../shared/graph-layout';
@@ -121,6 +120,8 @@ export interface CausalGraphEditorProps extends Settings {
     onUpdate?: (data: CausalGraph) => void | Promise<void>;
     /** Optional handler to process the edge style */
     processEdgeStyle?: (edge: PixiEdgeStyle, attributes: SimulationEdge) => PixiEdgeStyle;
+    /** Optional boolean defining whether a node and an edge can be selected simultaneously */
+    simultaneousEdgeNodeSelection?: boolean;
     /** Pass through of the native style prop */
     style?: React.CSSProperties;
     /** Optional parameter to force a tooltip to use a particular font size */
@@ -462,12 +463,16 @@ function CausalGraphEditor(props: CausalGraphEditorProps): JSX.Element {
     });
 
     useEngineEvent('nodeClick', (event, nodeId) => {
-        setSelectedEdge(null);
+        if (!props.simultaneousEdgeNodeSelection) {
+            setSelectedEdge(null);
+        }
         setSelectedNode(nodeId);
     });
 
     useEngineEvent('edgeClick', (event, source, target) => {
-        setSelectedNode(null);
+        if (!props.simultaneousEdgeNodeSelection) {
+            setSelectedNode(null);
+        }
         setSelectedEdge([source, target]);
     });
 


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
For some cases it was requested that it would be useful to be able to have an edge and a node selected at the same time.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Added a new property `simultaneousEdgeNodeSelection` to `CausalGraphEditor`. When set to true it stops if selecting a node for the edge to be set to null and vice versa.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
**Behaviour without the flag:**
![before click node:edge](https://github.com/causalens/dara-ui/assets/104359539/6a38884f-0912-4446-b3ae-3287e8cb390a)
**Behaviour with the flag:**
![after node:edge](https://github.com/causalens/dara-ui/assets/104359539/15344e6d-a2fc-4f76-945d-cafc72767c6c)
