### PR TITLE
Fix: DO-2112 datepicker with range when selecting end date overwrites start date

### DIFF
--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where if selecting the start or end date in a `Datepicker` always resulted in the user selecting the whole range instead of the selected input. 
+
 ## 1.4.4
 
 -   Added `onKeyDown` prop to NumericInput to bubble up keydown events

--- a/packages/ui-components/src/datepicker/datepicker.stories.tsx
+++ b/packages/ui-components/src/datepicker/datepicker.stories.tsx
@@ -44,7 +44,7 @@ DatepickerWithTime.args = { shouldCloseOnSelect: false, showTimeInput: true };
 
 export const DatepickerWithRange = (args: DatePickerProps): JSX.Element => <DatepickerComponent {...args} />;
 DatepickerWithRange.args = {
-    initialValue: [new Date('1995-12-17T03:24:00'), new Date()],
+    initialValue: [new Date('2024-01-17T03:24:00'), new Date()],
     selectsRange: true,
     shouldCloseOnSelect: false,
 };

--- a/packages/ui-components/src/datepicker/datepicker.tsx
+++ b/packages/ui-components/src/datepicker/datepicker.tsx
@@ -621,8 +621,6 @@ function DatePicker(props: DatePickerProps): JSX.Element {
     const [endDate, setEndDate] = useState<string>(() => getInitialDate(value, formatToApply, false));
     // state to track which date is being selected based on the input which has been interacted with
     const [isSelectingStart, setIsSelectingStart] = useState<boolean>(null);
-    // state to define whether the datepicker should be open or not so that this can be updated is useLayoutEffect when necessary
-    const [shouldDatepickerBeOpen, setShouldDatepickerBeOpen] = useState<boolean>(false);
 
     // Keep state in refs so we can compare it in useEffect without subscribing
     const selectedDateRef = useRef(selectedDate);
@@ -788,13 +786,6 @@ function DatePicker(props: DatePickerProps): JSX.Element {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedDate, selectedTime]);
 
-    // This needs to be useLayoutEffect as it needs to run before the datepicker is opened to avoid a jumping behaviour
-    useLayoutEffect(() => {
-        if (shouldDatepickerBeOpen === true) {
-            datepickerRef.current?.setOpen(true);
-        }
-    }, [shouldDatepickerBeOpen]);
-
     return (
         <>
             <Tooltip content={props.errorMsg} disabled={!props.errorMsg} styling="error">
@@ -807,19 +798,16 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                         <DateTimeWrapper isRange={props.selectsRange}>
                             <DateInput
                                 isTimeRange={props.selectsRange && props.showTimeInput}
-                                onBlur={() => {
-                                    setShouldDatepickerBeOpen(false);
-                                }}
                                 onChange={(e) => {
                                     onChangeDateInput(true, e);
                                 }}
                                 onClick={() => {
                                     setIsSelectingStart(true);
-                                    setShouldDatepickerBeOpen(true);
+                                    datepickerRef.current?.setOpen(true);
                                 }}
                                 onFocus={() => {
                                     setIsSelectingStart(true);
-                                    setShouldDatepickerBeOpen(true);
+                                    datepickerRef.current?.setOpen(true);
                                 }}
                                 onKeyDown={(e) => {
                                     datepickerRef.current?.onInputKeyDown(e);
@@ -844,19 +832,16 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                                 <DateTimeWrapper isRange>
                                     <DateInput
                                         isTimeRange={props.showTimeInput}
-                                        onBlur={() => {
-                                            setShouldDatepickerBeOpen(false);
-                                        }}
                                         onChange={(e) => {
                                             onChangeDateInput(false, e);
                                         }}
                                         onClick={() => {
                                             setIsSelectingStart(false);
-                                            setShouldDatepickerBeOpen(true);
+                                            datepickerRef.current?.setOpen(true);
                                         }}
                                         onFocus={() => {
                                             setIsSelectingStart(false);
-                                            setShouldDatepickerBeOpen(true);
+                                            datepickerRef.current?.setOpen(true);
                                         }}
                                         onKeyDown={(e) => {
                                             datepickerRef.current?.onInputKeyDown(e);
@@ -885,9 +870,6 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                         disabled={props.disabled}
                         inline={props.inline}
                         maxDate={props.maxDate}
-                        onBlur={() => {
-                            setShouldDatepickerBeOpen(false);
-                        }}
                         onChange={onChangeDate}
                         ref={datepickerRef}
                         selectsEnd={!isSelectingStart}

--- a/packages/ui-components/src/datepicker/datepicker.tsx
+++ b/packages/ui-components/src/datepicker/datepicker.tsx
@@ -20,7 +20,7 @@ import { format, parse } from 'date-fns';
 import enGB from 'date-fns/locale/en-GB';
 import { range } from 'lodash';
 import { transparentize } from 'polished';
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import ReactDatePicker, { ReactDatePickerProps } from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 

--- a/packages/ui-components/src/datepicker/datepicker.tsx
+++ b/packages/ui-components/src/datepicker/datepicker.tsx
@@ -20,7 +20,7 @@ import { format, parse } from 'date-fns';
 import enGB from 'date-fns/locale/en-GB';
 import { range } from 'lodash';
 import { transparentize } from 'polished';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import ReactDatePicker, { ReactDatePickerProps } from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 
@@ -218,15 +218,21 @@ const DatepickerWrapper = styled.div<DatepickerWrapperProps>`
                             background-color: ${(props) => transparentize(0.6, props.theme.colors.primary)};
                         }
                     }
-
+                
                     &.react-datepicker__day--in-range {
                         color: ${(props) => props.theme.colors.blue1};
-                        background-color: ${(props) => props.theme.colors.primary};
+                        background-color: ${(props) => transparentize(0.2, props.theme.colors.primary)};
                     }
 
                     &.react-datepicker__day--in-selecting-range {
                         color: ${(props) => props.theme.colors.blue1};
-                        background-color: ${(props) => transparentize(0.2, props.theme.colors.primary)};
+                        background-color: ${(props) => props.theme.colors.primary};
+                    }
+
+                    &.react-datepicker__day--selecting-range-end {
+                        font-weight: normal;
+                        color: ${(props) => props.theme.colors.blue1};
+                        background-color: ${(props) => props.theme.colors.primary};
                     }
 
                     &.react-datepicker__day--disabled {
@@ -613,6 +619,10 @@ function DatePicker(props: DatePickerProps): JSX.Element {
     const formatToApply = props.dateFormat ?? 'dd/MM/yyyy';
     const [startDate, setStartDate] = useState<string>(() => getInitialDate(value, formatToApply, true));
     const [endDate, setEndDate] = useState<string>(() => getInitialDate(value, formatToApply, false));
+    // state to track which date is being selected based on the input which has been interacted with
+    const [isSelectingStart, setIsSelectingStart] = useState<boolean>(null);
+    // state to define whether the datepicker should be open or not so that this can be updated is useLayoutEffect when necessary
+    const [shouldDatepickerBeOpen, setShouldDatepickerBeOpen] = useState<boolean>(false);
 
     // Keep state in refs so we can compare it in useEffect without subscribing
     const selectedDateRef = useRef(selectedDate);
@@ -623,10 +633,16 @@ function DatePicker(props: DatePickerProps): JSX.Element {
     const extraProps = useMemo(() => {
         if (props.selectsRange) {
             const selectedDates = (selectedDate ?? [null, null]) as [Date, Date];
+            let { minDate } = props;
+            // If we are selecting the end date minDate becomes whatever the startDate is
+            if (!isSelectingStart) {
+                const [currentStartDate] = selectedDates;
+                minDate = currentStartDate;
+            }
 
             return {
                 endDate: selectedDates[1],
-                selectsRange: true,
+                minDate,
                 startDate: selectedDates[0],
             };
         }
@@ -639,16 +655,35 @@ function DatePicker(props: DatePickerProps): JSX.Element {
         return {
             selected: date as Date,
         };
-    }, [props.selectsRange, selectedDate]);
+    }, [selectedDate, isSelectingStart, props]);
 
     const onChangeDate = (date: Date): void => {
-        setSelectedDate(date);
-        if (Array.isArray(date)) {
-            setStartDate(date[0] ? format(date[0], formatToApply) : '');
-            setEndDate(date[1] ? format(date[1], formatToApply) : '');
-            return;
+        // close datepicker when a date is chosen
+        datepickerRef.current?.setOpen(false);
+
+        if (props.selectsRange) {
+            // if range datepicker then update the correct part of the selected date
+            let currentStartDate;
+            let currentEndDate;
+
+            if (isSelectingStart) {
+                currentStartDate = date;
+                currentEndDate = Array.isArray(selectedDate) ? selectedDate[1] : null;
+                // if start date happens after end date then end date should become start
+                currentEndDate = currentEndDate && currentEndDate > date ? currentEndDate : date;
+            } else {
+                currentStartDate = Array.isArray(selectedDate) ? selectedDate[0] : null;
+                currentEndDate = date;
+            }
+
+            setStartDate(format(currentStartDate, formatToApply));
+            setEndDate(format(currentEndDate, formatToApply));
+            setSelectedDate([currentStartDate, currentEndDate]);
+        } else {
+            // if it is a single datepicker just update the selected date and start date
+            setSelectedDate(date);
+            setStartDate(format(date, formatToApply));
         }
-        setStartDate(format(date, formatToApply));
     };
 
     const onChangeDateInput = (isStartDate: boolean, e: React.SyntheticEvent<HTMLInputElement, Event>): void => {
@@ -753,6 +788,13 @@ function DatePicker(props: DatePickerProps): JSX.Element {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedDate, selectedTime]);
 
+    // This needs to be useLayoutEffect as it needs to run before the datepicker is opened to avoid a jumping behaviour
+    useLayoutEffect(() => {
+        if (shouldDatepickerBeOpen === true) {
+            datepickerRef.current?.setOpen(true);
+        }
+    }, [shouldDatepickerBeOpen]);
+
     return (
         <>
             <Tooltip content={props.errorMsg} disabled={!props.errorMsg} styling="error">
@@ -765,14 +807,19 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                         <DateTimeWrapper isRange={props.selectsRange}>
                             <DateInput
                                 isTimeRange={props.selectsRange && props.showTimeInput}
+                                onBlur={() => {
+                                    setShouldDatepickerBeOpen(false);
+                                }}
                                 onChange={(e) => {
                                     onChangeDateInput(true, e);
                                 }}
                                 onClick={() => {
-                                    datepickerRef.current?.setOpen(true);
+                                    setIsSelectingStart(true);
+                                    setShouldDatepickerBeOpen(true);
                                 }}
                                 onFocus={() => {
-                                    datepickerRef.current?.setOpen(true);
+                                    setIsSelectingStart(true);
+                                    setShouldDatepickerBeOpen(true);
                                 }}
                                 onKeyDown={(e) => {
                                     datepickerRef.current?.onInputKeyDown(e);
@@ -797,14 +844,19 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                                 <DateTimeWrapper isRange>
                                     <DateInput
                                         isTimeRange={props.showTimeInput}
+                                        onBlur={() => {
+                                            setShouldDatepickerBeOpen(false);
+                                        }}
                                         onChange={(e) => {
                                             onChangeDateInput(false, e);
                                         }}
                                         onClick={() => {
-                                            datepickerRef.current?.setOpen(true);
+                                            setIsSelectingStart(false);
+                                            setShouldDatepickerBeOpen(true);
                                         }}
                                         onFocus={() => {
-                                            datepickerRef.current?.setOpen(true);
+                                            setIsSelectingStart(false);
+                                            setShouldDatepickerBeOpen(true);
                                         }}
                                         onKeyDown={(e) => {
                                             datepickerRef.current?.onInputKeyDown(e);
@@ -833,9 +885,13 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                         disabled={props.disabled}
                         inline={props.inline}
                         maxDate={props.maxDate}
-                        minDate={props.minDate}
+                        onBlur={() => {
+                            setShouldDatepickerBeOpen(false);
+                        }}
                         onChange={onChangeDate}
                         ref={datepickerRef}
+                        selectsEnd={!isSelectingStart}
+                        selectsStart={isSelectingStart}
                         shouldCloseOnSelect={props.shouldCloseOnSelect}
                         {...extraProps}
                         popperProps={{ strategy: props.popperStrategy ?? 'absolute' }}

--- a/packages/ui-components/src/datepicker/datepicker.tsx
+++ b/packages/ui-components/src/datepicker/datepicker.tsx
@@ -657,7 +657,9 @@ function DatePicker(props: DatePickerProps): JSX.Element {
 
     const onChangeDate = (date: Date): void => {
         // close datepicker when a date is chosen
-        datepickerRef.current?.setOpen(false);
+        if (props.shouldCloseOnSelect) {
+            datepickerRef.current?.setOpen(false);
+        }
 
         if (props.selectsRange) {
             // if range datepicker then update the correct part of the selected date


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
User feedback that datepicker was annoying to use as when we selected the end date input it still forced user to select the whole range again.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Applied `selectsStart ` and  `selectsEnd` to ReactDatepicker. This allows us to define the behaviour of the range selected based on the input which has been interacted with.

Also had to make some CSS changes so that the behaviour as you select values in the range looked as you would expect. This behaviour is shown in the gif below.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->

![datepicker](https://github.com/causalens/dara-ui/assets/104359539/c8581a12-2f51-4975-b80e-742cd2f4278e)
