### PR TITLE
Improvement: DO-2449 offset `ContextMenu` few pixels from the cursor

### DIFF
--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -2,9 +2,13 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   `ContextMenu` component is now offset a few pixels from the cursor to prevent the first item from being accidentally selected when the context menu is opened.
+
 ## 1.5.2
 
--   Fixed an issue where if selecting the start or end date in a `Datepicker` always resulted in the user selecting the whole range instead of the selected input. 
+-   Fixed an issue where if selecting the start or end date in a `Datepicker` always resulted in the user selecting the whole range instead of the selected input.
 -   Fixed an issue where the filled button in the dark theme was using the wrong color, now it uses `blue1` color.
 
 ## 1.4.4

--- a/packages/ui-components/src/context-menu/context-menu.tsx
+++ b/packages/ui-components/src/context-menu/context-menu.tsx
@@ -121,10 +121,11 @@ function ContextMenu<T>(Component: React.ComponentType<T> | string): (props: Con
             document.dispatchEvent(new Event('contextmenu'));
             e.preventDefault();
             e.stopPropagation();
+
             boundingRectRef.current = {
                 ...boundingRectRef.current,
-                left: e.clientX,
-                top: e.clientY,
+                left: e.clientX + 2,
+                top: e.clientY - 4,
             };
             update();
             setShowMenu(true);


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

It was reported that the first option of the context menu can be easily clicked by accident, especially when using a touchpad.

This is now improved by offsetting the menu position a few pixels away from the cursor which matches closely the native context menu behaviour.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->

https://github.com/causalens/dara-ui/assets/87647189/40384ebf-d4a5-4458-b082-9e232ba85839

