### PR TITLE
Improvement: DO-1585 custsup ability to add custom legends to causalgraphviewer (1/4)

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 -   Updated the type of `additionalLegends` to also allow defining nodes
+-   Added a new prop `defaultLegends` which allows default legends to be passed based on each `EditorMode`. Consequently the default legends have been removed from this package and moved to dara.
 
 ## 1.5.2
 

--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Updated the type of `additionalLegends` to also allow defining nodes
+
 ## 1.5.2
 
 -   Added `layeringAlgorithm` prop to `PlanarLayout`, which allows the ability to define the layering algorithm between default `SIMPLEX` or `LONGEST_PATH`

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -99,6 +99,8 @@ export interface CausalGraphEditorProps extends Settings {
     availableInputs?: string[];
     /** Standard class name prop */
     className?: string;
+    /** default legends per editor mode */
+    defaultLegends?: Record<EditorMode, GraphLegendDefinition[]>;
     /** Any extra sections to display in the side panel on edge click */
     edgeExtrasContent?: React.ReactElement;
     /** The backend data */
@@ -623,7 +625,11 @@ function CausalGraphEditor(props: CausalGraphEditorProps): JSX.Element {
                         onMouseLeave={() => setShowFrameButtons(false)}
                     >
                         <Overlay
-                            bottomLeft={<Legend listItems={getLegendData(editorMode, props.additionalLegends)} />}
+                            bottomLeft={
+                                <Legend
+                                    listItems={getLegendData(props.defaultLegends, editorMode, props.additionalLegends)}
+                                />
+                            }
                             onDelete={onDelete}
                             onNext={onNext}
                             onPrev={onPrev}

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -31,8 +31,8 @@ import {
     CenterGraphButton,
     DragModeButton,
     EdgeInfoContent,
+    GraphLegendDefinition,
     Legend,
-    LegendLineDefinition,
     NodeInfoContent,
     Overlay,
     RecalculateLayoutButton,
@@ -94,7 +94,7 @@ const NotificationWrapper = styled.div`
 
 export interface CausalGraphEditorProps extends Settings {
     /** Optional additional legends to show */
-    additionalLegends?: LegendLineDefinition[];
+    additionalLegends?: GraphLegendDefinition[];
     /** Input nodes */
     availableInputs?: string[];
     /** Standard class name prop */

--- a/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
@@ -133,19 +133,6 @@ Interactive.args = {
     graphLayout: PlanarLayout.Builder.build(),
 };
 
-// /** Arrow to show at end of line */
-// arrowType?: 'none' | 'normal' | 'filled' | 'empty' | 'soft';
-// /** Symbol to show in the center of the arrow */
-// centerSymbol?: 'none' | 'cross' | 'question' | 'bidirected';
-// /** color to represent */
-// color?: keyof DefaultTheme['colors'];
-// /** dashArray SVG path property - line will be dashed if specified */
-// dashArray?: string;
-// /** legend label */
-// label?: string;
-// /** Show empty spot instead of a legend line */
-// spacer?: boolean;
-
 export const MarketingBottom = Template.bind({});
 MarketingBottom.args = {
     additionalLegends: [
@@ -158,6 +145,14 @@ MarketingBottom.args = {
         },
         {
             label: 'test node',
+            type: 'node',
+        },
+        {
+            label: 'another node',
+            symbol: {
+                color: 'red',
+                highlight_color: 'green',
+            },
             type: 'node',
         },
     ],

--- a/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
@@ -133,8 +133,34 @@ Interactive.args = {
     graphLayout: PlanarLayout.Builder.build(),
 };
 
+// /** Arrow to show at end of line */
+// arrowType?: 'none' | 'normal' | 'filled' | 'empty' | 'soft';
+// /** Symbol to show in the center of the arrow */
+// centerSymbol?: 'none' | 'cross' | 'question' | 'bidirected';
+// /** color to represent */
+// color?: keyof DefaultTheme['colors'];
+// /** dashArray SVG path property - line will be dashed if specified */
+// dashArray?: string;
+// /** legend label */
+// label?: string;
+// /** Show empty spot instead of a legend line */
+// spacer?: boolean;
+
 export const MarketingBottom = Template.bind({});
 MarketingBottom.args = {
+    additionalLegends: [
+        {
+            label: 'test arrow',
+            type: 'edge',
+        },
+        {
+            type: 'none',
+        },
+        {
+            label: 'test node',
+            type: 'node',
+        },
+    ],
     editable: true,
     graphData: causalGraph,
     graphLayout: MarketingLayout.Builder.build(),

--- a/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
@@ -129,6 +129,16 @@ export const Interactive = (args: CausalGraphEditorProps): JSX.Element => {
     );
 };
 Interactive.args = {
+    additionalLegends: [
+        {
+            label: 'Other',
+            type: 'node',
+        },
+        {
+            label: 'Other',
+            type: 'edge',
+        },
+    ],
     editable: true,
     graphLayout: PlanarLayout.Builder.build(),
 };
@@ -141,7 +151,7 @@ MarketingBottom.args = {
             type: 'edge',
         },
         {
-            type: 'none',
+            type: 'spacer',
         },
         {
             label: 'test node',

--- a/packages/ui-causal-graph-editor/src/index.tsx
+++ b/packages/ui-causal-graph-editor/src/index.tsx
@@ -36,5 +36,6 @@ export { default as GraphContext } from './shared/graph-context';
 export { causalGraphParser } from './shared/parsers';
 export { causalGraphSerializer, serializeGraphEdge, serializeGraphNode } from './shared/serializer';
 export { GraphActionCreators, GraphReducer } from './shared/causal-graph-store';
+export { GraphLegendDefinition } from './shared/editor-overlay';
 export { FloatingButton } from './shared/editor-overlay/floating-elements';
 export { PixiEdgeStyle } from './shared/rendering/edge';

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/index.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/index.tsx
@@ -17,5 +17,5 @@
 export { default as Overlay } from './overlay';
 export { RecalculateLayoutButton, AddNodeButton, DragModeButton, CenterGraphButton } from './buttons';
 export { SearchBar, useSearch } from './search-bar';
-export { Legend, LegendLineDefinition, getLegendData } from './legend';
+export { Legend, GraphLegendDefinition, getLegendData } from './legend';
 export { PanelContent, NodeInfoContent, EdgeInfoContent } from './panel-content';

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/index.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/index.tsx
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 export { default as Legend } from './legend';
-export { LegendLineDefinition, getLegendData } from './legend-data';
+export { GraphLegendDefinition, getLegendData } from './legend-data';

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-data.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-data.tsx
@@ -55,7 +55,7 @@ export function getLegendData(
     editorMode: EditorMode,
     additionalLegend: GraphLegendDefinition[]
 ): GraphLegendDefinition[] {
-    const modeData = defaultLegends[editorMode] ?? [];
+    const modeData = defaultLegends?.[editorMode] ?? [];
 
     return [...modeData, ...(additionalLegend ?? []).filter(Boolean)];
 }

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-data.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-data.tsx
@@ -28,7 +28,7 @@ export interface LegendArrowDefinition {
     arrowType?: 'none' | 'normal' | 'filled' | 'empty' | 'soft';
     /** Symbol to show in the center of the arrow */
     centerSymbol?: 'none' | 'cross' | 'question' | 'bidirected';
-    /** defines the filled color of the node symbol */
+    /** defines the filled color of the edge/arrow symbol */
     color?: string;
     /** dashArray SVG path property - line will be dashed if specified */
     dashArray?: string;

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-data.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-data.tsx
@@ -16,107 +16,46 @@
  */
 import { EditorMode } from '@types';
 
-export interface LegendNodeDefinition {
-    /** defines the filled color of the node symbol */
-    color?: string;
-    /** defines the border color of the node symbol */
-    highlight_color?: string;
-}
+export interface LegendNodeDefinition {}
 
-export interface LegendArrowDefinition {
-    /** Arrow to show at end of line */
-    arrowType?: 'none' | 'normal' | 'filled' | 'empty' | 'soft';
-    /** Symbol to show in the center of the arrow */
-    centerSymbol?: 'none' | 'cross' | 'question' | 'bidirected';
-    /** defines the filled color of the edge/arrow symbol */
-    color?: string;
-    /** dashArray SVG path property - line will be dashed if specified */
-    dashArray?: string;
-}
-
-/**  Union type for the 'type' property */
-type GraphSymbolType = 'none' | 'edge' | 'node';
-
-interface BaseGraphLegendDefinition {
-    /** legend label */
-    label?: string;
-    /** legend symbol type */
-    type: GraphSymbolType;
-}
-
-// Extend the base interface for each specific 'type' value
-interface NoneGraphLegendDefinition extends BaseGraphLegendDefinition {
-    symbol?: never;
-    type: 'none'; // No symbol for 'none' type
-}
-
-export interface EdgeGraphLegendDefinition extends BaseGraphLegendDefinition {
-    symbol?: LegendArrowDefinition;
-    type: 'edge';
-}
-
-export interface NodeGraphLegendDefinition extends BaseGraphLegendDefinition {
-    symbol?: LegendNodeDefinition;
-    type: 'node';
-}
-
-export type GraphLegendDefinition = NoneGraphLegendDefinition | EdgeGraphLegendDefinition | NodeGraphLegendDefinition;
-
-const RESOLVER_LEGEND: GraphLegendDefinition[] = [
-    {
-        label: 'Unresolved',
-        symbol: {
-            centerSymbol: 'question',
-            dashArray: '10 6',
-        },
-        type: 'edge',
-    },
-    {
-        label: 'Not accepted',
-        symbol: {
-            dashArray: '10 6',
-        },
-        type: 'edge',
-    },
-    {
-        label: 'Accepted',
-        symbol: {
-            dashArray: '6 4',
-        },
-        type: 'edge',
-    },
-    {
-        label: 'Domain knowledge',
-        symbol: {},
-        type: 'edge',
-    },
-];
-
-const PAG_LEGEND: GraphLegendDefinition[] = [
-    { label: 'Directed', symbol: { arrowType: 'filled' }, type: 'edge' },
-    { label: 'Wildcard', symbol: { arrowType: 'empty' }, type: 'edge' },
-    { label: 'Undirected', symbol: { arrowType: 'none' }, type: 'edge' },
-];
-
-const ENCODER_LEGEND: GraphLegendDefinition[] = [
-    { label: 'Hard Directed', type: 'edge' },
-    { label: 'Soft Directed', symbol: { arrowType: 'soft' }, type: 'edge' },
-    { label: 'Undirected', symbol: { arrowType: 'none', centerSymbol: 'bidirected' }, type: 'edge' },
-    { label: 'Prohibited', symbol: { arrowType: 'none', centerSymbol: 'cross' }, type: 'edge' },
-];
-
-const DEFAULT_LEGENDS: Map<EditorMode, GraphLegendDefinition[]> = new Map([
-    [EditorMode.DEFAULT, []],
-    [EditorMode.PAG_VIEWER, PAG_LEGEND],
-    [EditorMode.RESOLVER, RESOLVER_LEGEND],
-    [EditorMode.EDGE_ENCODER, ENCODER_LEGEND],
-]);
+export type GraphLegendDefinition =
+    | {
+          /** defines the label for the legend entry */
+          label?: string;
+          /** the type of the symbol to show */
+          type: 'spacer';
+      }
+    | {
+          /** Arrow to show at end of line */
+          arrow_type?: 'none' | 'normal' | 'filled' | 'empty' | 'soft';
+          /** Symbol to show in the center of the arrow */
+          center_symbol?: 'none' | 'cross' | 'question' | 'bidirected';
+          /** defines the filled color of the edge/arrow symbol */
+          color?: string;
+          /** dashArray SVG path property - line will be dashed if specified */
+          dash_array?: string;
+          /** defines the label for the legend entry */
+          label?: string;
+          /** the type of the symbol to show */
+          type: 'edge';
+      }
+    | {
+          /** defines the filled color of the node symbol */
+          color?: string;
+          /** defines the border color of the node symbol */
+          highlight_color?: string;
+          /** defines the label for the legend entry */
+          label?: string;
+          /** the type of the symbol to show */
+          type: 'node';
+      };
 
 export function getLegendData(
+    defaultLegends: Record<EditorMode, GraphLegendDefinition[]>,
     editorMode: EditorMode,
     additionalLegend: GraphLegendDefinition[]
 ): GraphLegendDefinition[] {
-    const modeData = DEFAULT_LEGENDS.get(editorMode) ?? [];
+    const modeData = defaultLegends[editorMode] ?? [];
 
     return [...modeData, ...(additionalLegend ?? []).filter(Boolean)];
 }

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-list.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-list.tsx
@@ -16,7 +16,7 @@
  */
 import styled, { useTheme } from '@darajs/styled-components';
 
-import { GraphLegendDefinition, LegendArrowDefinition } from './legend-data';
+import { GraphLegendDefinition } from './legend-data';
 
 const LegendText = styled.span`
     color: ${(props) => props.theme.colors.text};
@@ -123,14 +123,18 @@ function HalfCircle(props: SvgProps): JSX.Element {
     );
 }
 
-const CenterSymbols: Record<LegendArrowDefinition['centerSymbol'], (props: SvgProps) => JSX.Element> = {
+type CenterSymbolType = Extract<GraphLegendDefinition, { type: 'edge' }>['center_symbol'];
+
+const CenterSymbols: Record<CenterSymbolType, (props: SvgProps) => JSX.Element> = {
     bidirected: Bidirected,
     cross: Cross,
     none: null,
     question: QuestionMark,
 };
 
-const Arrows: Record<LegendArrowDefinition['arrowType'], (props: SvgProps) => JSX.Element> = {
+type ArrowsType = Extract<GraphLegendDefinition, { type: 'edge' }>['arrow_type'];
+
+const Arrows: Record<ArrowsType, (props: SvgProps) => JSX.Element> = {
     empty: EmptyCircle,
     filled: FullArrow,
     none: null,
@@ -141,12 +145,12 @@ const Arrows: Record<LegendArrowDefinition['arrowType'], (props: SvgProps) => JS
 /**
  * Component to generate a legend line
  */
-function LegendSymbol({ label, type, symbol }: GraphLegendDefinition): JSX.Element {
+function LegendSymbol(props: GraphLegendDefinition): JSX.Element {
     const theme = useTheme();
 
-    if (type === 'node') {
-        const fillColor = symbol?.color ?? theme.colors.blue4;
-        const borderColor = symbol?.highlight_color ?? theme.colors.primary;
+    if (props.type === 'node') {
+        const fillColor = props?.color ?? theme.colors.blue4;
+        const borderColor = props?.highlight_color ?? theme.colors.primary;
 
         return (
             <svg height="16px" viewBox="-40 0 100 25">
@@ -155,18 +159,18 @@ function LegendSymbol({ label, type, symbol }: GraphLegendDefinition): JSX.Eleme
         );
     }
 
-    if (type === 'edge') {
-        const edgeColor = symbol?.color ?? theme.colors.grey5;
+    if (props.type === 'edge') {
+        const edgeColor = props?.color ?? theme.colors.grey5;
 
-        const Symbol = CenterSymbols[symbol?.centerSymbol ?? 'none'];
-        const Arrow = Arrows[symbol?.arrowType ?? 'normal'];
+        const Symbol = CenterSymbols[props?.center_symbol ?? 'none'];
+        const Arrow = Arrows[props?.arrow_type ?? 'normal'];
 
         return (
             <svg height="16px" viewBox="-40 0 100 25">
-                <g key={label}>
+                <g key={props.label}>
                     <line
                         stroke={edgeColor}
-                        strokeDasharray={symbol?.dashArray ?? 'none'}
+                        strokeDasharray={props?.dash_array ?? 'none'}
                         strokeWidth={4}
                         style={{ opacity: 0.5 }}
                         x1={-25}
@@ -192,7 +196,7 @@ export function LegendList({ listItems }: LegendListProps): JSX.Element {
         <Ul>
             {listItems.map(({ label, ...props }) => (
                 <Li key={label}>
-                    <LegendSymbol {...props} label={label} />
+                    <LegendSymbol {...props} />
                     <LegendText>{label}</LegendText>
                 </Li>
             ))}

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-list.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-list.tsx
@@ -16,7 +16,7 @@
  */
 import styled, { useTheme } from '@darajs/styled-components';
 
-import { LegendLineDefinition } from './legend-data';
+import { GraphLegendDefinition, LegendArrowDefinition } from './legend-data';
 
 const LegendText = styled.span`
     color: ${(props) => props.theme.colors.text};
@@ -123,14 +123,14 @@ function HalfCircle(props: SvgProps): JSX.Element {
     );
 }
 
-const CenterSymbols: Record<LegendLineDefinition['centerSymbol'], (props: SvgProps) => JSX.Element> = {
+const CenterSymbols: Record<LegendArrowDefinition['centerSymbol'], (props: SvgProps) => JSX.Element> = {
     bidirected: Bidirected,
     cross: Cross,
     none: null,
     question: QuestionMark,
 };
 
-const Arrows: Record<LegendLineDefinition['arrowType'], (props: SvgProps) => JSX.Element> = {
+const Arrows: Record<LegendArrowDefinition['arrowType'], (props: SvgProps) => JSX.Element> = {
     empty: EmptyCircle,
     filled: FullArrow,
     none: null,
@@ -141,54 +141,58 @@ const Arrows: Record<LegendLineDefinition['arrowType'], (props: SvgProps) => JSX
 /**
  * Component to generate a legend line
  */
-function LegendLine({
-    label,
-    color = 'grey5',
-    dashArray,
-    arrowType = 'normal',
-    centerSymbol = 'none',
-    spacer,
-}: LegendLineDefinition): JSX.Element {
+function LegendSymbol({ label, type, symbol }: GraphLegendDefinition): JSX.Element {
     const theme = useTheme();
 
-    if (spacer) {
-        return <span style={{ height: '0.5rem', width: '100%' }} />;
+    if (type === 'node') {
+        const fillColor = symbol?.color ?? theme.colors.blue4;
+        const borderColor = symbol?.highlight_color ?? theme.colors.primary;
+
+        return (
+            <svg height="16px" viewBox="-40 0 100 25">
+                <circle cx="10" cy="12" fill={fillColor} r="12" stroke={borderColor} strokeWidth="1" />
+            </svg>
+        );
     }
 
-    const Symbol = CenterSymbols[centerSymbol];
-    const Arrow = Arrows[arrowType];
+    if (type === 'edge') {
+        const edgeColor = symbol?.color ?? theme.colors.grey5;
 
-    return (
-        <svg height="12px" viewBox="-40 0 100 20">
-            <g key={label}>
-                <line
-                    stroke={theme.colors[color]}
-                    strokeDasharray={dashArray ?? 'none'}
-                    strokeWidth={4}
-                    style={{ opacity: 0.5 }}
-                    x1={-25}
-                    x2={40}
-                    y1={10}
-                    y2={10}
-                />
-                {Symbol && (
-                    <Symbol color={theme.colors[color]} fill={theme.colors.blue1} transform="translate (0, 2)" />
-                )}
-                {Arrow && <Arrow color={theme.colors[color]} fill={theme.colors.blue1} transform="translate(25, 1)" />}
-            </g>
-        </svg>
-    );
+        const Symbol = CenterSymbols[symbol?.centerSymbol ?? 'none'];
+        const Arrow = Arrows[symbol?.arrowType ?? 'normal'];
+
+        return (
+            <svg height="16px" viewBox="-40 0 100 25">
+                <g key={label}>
+                    <line
+                        stroke={edgeColor}
+                        strokeDasharray={symbol?.dashArray ?? 'none'}
+                        strokeWidth={4}
+                        style={{ opacity: 0.5 }}
+                        x1={-25}
+                        x2={40}
+                        y1={10}
+                        y2={10}
+                    />
+                    {Symbol && <Symbol color={edgeColor} fill={theme.colors.blue1} transform="translate (0, 2)" />}
+                    {Arrow && <Arrow color={edgeColor} fill={theme.colors.blue1} transform="translate(25, 1)" />}
+                </g>
+            </svg>
+        );
+    }
+
+    return <span style={{ height: '0.5rem', width: '100%' }} />;
 }
 
 export interface LegendListProps {
-    listItems: LegendLineDefinition[];
+    listItems: GraphLegendDefinition[];
 }
 export function LegendList({ listItems }: LegendListProps): JSX.Element {
     return (
         <Ul>
             {listItems.map(({ label, ...props }) => (
                 <Li key={label}>
-                    <LegendLine {...props} label={label} />
+                    <LegendSymbol {...props} label={label} />
                     <LegendText>{label}</LegendText>
                 </Li>
             ))}

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-list.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-list.tsx
@@ -154,7 +154,7 @@ function LegendSymbol(props: GraphLegendDefinition): JSX.Element {
 
         return (
             <svg height="16px" viewBox="-40 0 100 25">
-                <circle cx="10" cy="12" fill={fillColor} r="12" stroke={borderColor} strokeWidth="1" />
+                <circle cx="8" cy="12" fill={fillColor} r="12" stroke={borderColor} strokeWidth="1" />
             </svg>
         );
     }

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend.tsx
@@ -87,6 +87,7 @@ function Legend(props: LegendProps): JSX.Element {
             <LegendWrapper
                 ref={panelRef}
                 style={{
+                    minWidth: '13rem',
                     opacity: showLegend ? 1 : 0,
                     pointerEvents: !showLegend || disablePointerEvents ? 'none' : 'all',
                     transform: showLegend ? 'scale(1)' : 'scale(0)',


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Make adding custom legend to graphs easier, also expand it to also allow to define nodes in the legend

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
I have updated the type of `additionalLegends` to accept a set of equal props: label, type and symbol which together can be used to define the legend the user wants to show in the graph. It now accepts a list of `GraphLegendDefinition`. 

You can define it as:
```
{
    label: my label
    type: node
    symbol: {
        color: red
    }
} 
```

Depending on the type chosen symbol takes either node properties or edge properties. These are optional and if not set just show the default node/edge color/style. If type is set to none, the user can use that to show a spacer.

Dara side tickets to follow

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
<img width="1208" alt="Screenshot 2024-02-08 at 13 58 25" src="https://github.com/causalens/dara-ui/assets/104359539/f3f3307a-36e5-4c60-b22f-4fcea38f2924">

