### PR TITLE
Improvement: DO-2575: Disable UploadDropzone paste event by default

### DIFF
--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   `UploadDropzone` now has `enablePaste` prop to conditionally activate paste functionality, allowing for more customizable behavior. By default, pasting text directly into the `UploadDropzone` is now disabled, requiring explicit activation via the `enablePaste` prop.
+
 ## 1.6.0
 
 -   `ContextMenu` component is now offset a few pixels from the cursor to prevent the first item from being accidentally selected when the context menu is opened.

--- a/packages/ui-components/src/dropzone/dropzone.tsx
+++ b/packages/ui-components/src/dropzone/dropzone.tsx
@@ -63,6 +63,8 @@ export interface UploadDropzoneProps {
     accept?: string;
     /** Standard react className property */
     className?: string;
+    /** Determines if the paste event listener should be enabled, allowing for direct pasting of text as files. */
+    enablePaste?: boolean;
     /** An onDrop handler that is called when a file is dropped or selected from the */
     onDrop: (acceptedFiles: Array<File>) => void | Promise<void>;
     /** Styling property */
@@ -77,6 +79,9 @@ export interface UploadDropzoneProps {
  */
 function UploadDropzone(props: UploadDropzoneProps): JSX.Element {
     useEffect(() => {
+        if (!props.enablePaste) {
+            return;
+        }
         const handlePaste = (ev: ClipboardEvent): void => {
             const blob = new Blob([ev.clipboardData.getData('Text')], { type: 'text/plain' });
             const file = new File([blob], 'pasted_data', { type: 'text/plain' });


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Right now `UploadDropzone` includes an unconditional event handler for any `paste` event. This is fine for use in full-page apps, but presents a problem when it is used in larger pages with multiple components.

This PR adds an `enablePaste` prop that will control whether the `paste` event listener is enabled or not. By default, it is now disabled, requiring explicit activation.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally. It looks like storybook doesn't forward the paste event, so just send it manually:
```tsx
function triggerPasteEvent(text) {
  const event = new ClipboardEvent('paste', {
    bubbles: true,
    cancelable: true,
    clipboardData: new DataTransfer()
  });
  event.clipboardData.setData('text/plain', text);
  document.dispatchEvent(event);
} 
```

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->