### PR TITLE
Improvement: DO-2603 require click on canvas to zoom with mousewheel for graph viewer

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 -   Zooming the graph with mousewheel is now disabled by default and requires first focusing the graph by clicking on it. This is to prevent accidental zooming when scrolling through the page.
+The previous behaviour can be restored by setting `requireFocusToZoom` prop to true.
 
 ## 1.6.0
 

--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Zooming the graph with mousewheel is now disabled by default and requires first focusing the graph by clicking on it. This is to prevent accidental zooming when scrolling through the page.
+
 ## 1.6.0
 
 -   Updated the type of `additionalLegends` to also allow defining nodes
@@ -13,8 +17,8 @@ title: Changelog
 
 ## 1.5.1
 
--   Added `simultaneousEdgeNodeSelection` prop to `CausalGraphEditor` which when set to true allows for both an edge and a node to be selected simultaneously. 
--   If `TimeSeriesCausalGraph` object is passed to `CausalGraphEditor` and no tiers are defines, it now uses `time_lag` and `variable_name` to define the `order_nodes_by` and `group` respectively. 
+-   Added `simultaneousEdgeNodeSelection` prop to `CausalGraphEditor` which when set to true allows for both an edge and a node to be selected simultaneously.
+-   If `TimeSeriesCausalGraph` object is passed to `CausalGraphEditor` and no tiers are defines, it now uses `time_lag` and `variable_name` to define the `order_nodes_by` and `group` respectively.
 -   Fixed an issue where we couldn't set `tiers` to the `PlanarLayoutBuilder`.
 
 ## 1.5.0

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -654,6 +654,16 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
                         onMouseLeave={() => setShowFrameButtons(false)}
                     >
                         <Overlay
+                            bottomLeft={
+                                <Legend
+                                    listItems={getLegendData(props.defaultLegends, editorMode, props.additionalLegends)}
+                                />
+                            }
+                            onDelete={onDelete}
+                            onNext={onNext}
+                            onPrev={onPrev}
+                            showFrameButtons={!isDragging && (showFrameButtons || hasFocus)}
+                            title={panelTitle}
                             topCenter={
                                 <>
                                     {showZoomPrompt && (
@@ -665,16 +675,6 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
                                     )}
                                 </>
                             }
-                            bottomLeft={
-                                <Legend
-                                    listItems={getLegendData(props.defaultLegends, editorMode, props.additionalLegends)}
-                                />
-                            }
-                            onDelete={onDelete}
-                            onNext={onNext}
-                            onPrev={onPrev}
-                            showFrameButtons={!isDragging && (showFrameButtons || hasFocus)}
-                            title={panelTitle}
                             topLeft={<RecalculateLayoutButton onResetLayout={resetLayout} />}
                             topRight={
                                 <>

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/overlay.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/overlay.tsx
@@ -20,9 +20,19 @@ import PointerContext from '@shared/pointer-context';
 import { useSettings } from '@shared/settings-context';
 
 import { PanelContent } from './panel-content';
-import { BottomDiv, BottomLeftDiv, BottomRightDiv, TopDiv, TopLeftDiv, TopRightDiv } from './positional-divs';
+import {
+    BottomDiv,
+    BottomLeftDiv,
+    BottomRightDiv,
+    TopCenterDiv,
+    TopDiv,
+    TopLeftDiv,
+    TopRightDiv,
+} from './positional-divs';
 
 interface EditorOverlayProps {
+    /** Render prop for content which will be absolute positioned */
+    topCenter?: React.ReactNode;
     /** Render prop for content to place in the bottom left of the overlay */
     bottomLeft?: React.ReactNode;
     /** Render prop for content to place in the bottom right of the overlay */
@@ -73,6 +83,9 @@ function EditorOverlay(props: EditorOverlayProps): JSX.Element {
                 <TopLeftDiv onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit}>
                     {props.topLeft}
                 </TopLeftDiv>
+                <TopCenterDiv onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit}>
+                    {props.topCenter}
+                </TopCenterDiv>
                 <TopRightDiv onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit}>
                     {props.topRight}
                 </TopRightDiv>

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/overlay.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/overlay.tsx
@@ -31,8 +31,6 @@ import {
 } from './positional-divs';
 
 interface EditorOverlayProps {
-    /** Render prop for content which will be absolute positioned */
-    topCenter?: React.ReactNode;
     /** Render prop for content to place in the bottom left of the overlay */
     bottomLeft?: React.ReactNode;
     /** Render prop for content to place in the bottom right of the overlay */
@@ -51,6 +49,8 @@ interface EditorOverlayProps {
     showFrameButtons?: boolean;
     /** Panel title */
     title?: string;
+    /** Render prop for content to place in the top center of the overlay */
+    topCenter?: React.ReactNode;
     /** Render prop for content to place in the top left of the overlay */
     topLeft?: React.ReactNode;
     /** Render prop for content to place in the top right of the overlay */

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/positional-divs.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/positional-divs.tsx
@@ -50,6 +50,8 @@ export const BottomDiv = styled(OverlayDiv)<{ padding: string }>`
 
 export const TopDiv = styled(OverlayDiv)<{ padding: string }>`
     pointer-events: none;
+    gap: 1.5rem;
+
     top: ${applyPadding};
     right: ${applyPadding};
     left: ${applyPadding};
@@ -75,6 +77,14 @@ export const TopLeftDiv = styled(CornerDiv)`
     z-index: 5;
     align-items: flex-start;
     justify-content: end;
+`;
+export const TopCenterDiv = styled(CornerDiv)`
+    z-index: 5;
+    align-items: flex-start;
+    justify-content: center;
+    /* Allow the center to shrink */
+    min-width: 0;
+    flex-shrink: 1;
 `;
 export const BottomRightDiv = styled(CornerDiv)`
     z-index: 5;

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
@@ -60,8 +60,8 @@ const CloseButton = styled(Button)`
     height: auto;
 `;
 
-const blurredText = 'To enable zooming with scroll, click the viewer area' as const;
-const focusedText = 'To disable zooming on scroll, click out of the viewer area' as const;
+const blurredText = 'To zoom in/out with scroll, click the viewer area.' as const;
+const focusedText = 'To disable zoom in/out with scroll, click out of the viewer area.' as const;
 
 export default function ZoomPrompt(props: ZoomPromptProps): React.ReactElement {
     const { disablePointerEvents, onPanelEnter, onPanelExit } = React.useContext(PointerContext);

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
@@ -1,0 +1,104 @@
+import { mix } from 'polished';
+import * as React from 'react';
+
+import styled from '@darajs/styled-components';
+import { Button, Tooltip } from '@darajs/ui-components';
+import { Xmark } from '@darajs/ui-icons';
+
+import PointerContext from '@shared/pointer-context';
+
+interface ZoomPromptProps {
+    hasFocus: boolean;
+    onClose: () => void;
+    onDismiss: () => void;
+}
+
+const PromptWrapper = styled.div`
+    padding: 0 0.5rem;
+    background-color: ${({ theme }) => mix(0.1, theme.colors.grey2, theme.colors.blue1)};
+    border: 1px solid ${({ theme }) => theme.colors.grey2};
+    color: ${({ theme }) => theme.colors.grey4};
+    flex-shrink: 1;
+    min-width: 0;
+
+    border-radius: 4px;
+
+    font-size: 0.875rem;
+
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+`;
+
+const DismissText = styled.span`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 5ch;
+`;
+
+const DismissButton = styled(Button)`
+    background-color: transparent;
+    font-size: 0.875rem;
+    flex-shrink: 0;
+    padding: 0.25rem;
+
+    &:hover:not(:disabled) {
+        background-color: transparent;
+        text-decoration: underline;
+    }
+`;
+
+const CloseButton = styled(Button)`
+    padding: 0.25rem;
+    height: auto;
+`;
+
+const blurredText = 'To enable zooming with scroll, click the viewer area' as const;
+const focusedText = 'To disable zooming on scroll, click out of the viewer area' as const;
+
+export default function ZoomPrompt(props: ZoomPromptProps): React.ReactElement {
+    const { disablePointerEvents, onPanelEnter, onPanelExit } = React.useContext(PointerContext);
+
+    const [showTooltip, setShowTooltip] = React.useState(false);
+
+    const textRef = React.useRef<HTMLSpanElement>(null);
+    React.useEffect(() => {
+        // use observer to detect text overflow
+        const observer = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                // check if text is overflowing
+                const isOverflowing = entry.target.scrollWidth > entry.target.clientWidth;
+                setShowTooltip(isOverflowing);
+            }
+        });
+
+        if (textRef.current) {
+            observer.observe(textRef.current);
+        }
+
+        return () => {
+            observer.disconnect();
+        };
+    }, [textRef]);
+
+    const style: React.CSSProperties = {
+        pointerEvents: disablePointerEvents ? 'none' : 'all',
+    };
+
+    const textContent = props.hasFocus ? focusedText : blurredText;
+
+    return (
+        <PromptWrapper onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit} style={style}>
+            <Tooltip content={textContent} disabled={!showTooltip}>
+                <DismissText ref={textRef}>{textContent}</DismissText>
+            </Tooltip>
+            <DismissButton onClick={props.onDismiss} styling="ghost">
+                Don&apos;t show again
+            </DismissButton>
+            <CloseButton onClick={props.onClose} styling="ghost">
+                <Xmark size="lg" />
+            </CloseButton>
+        </PromptWrapper>
+    );
+}

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
@@ -15,9 +15,9 @@ interface ZoomPromptProps {
 
 const PromptWrapper = styled.div`
     padding: 0.25rem 0.5rem;
-    background-color: ${({ theme }) => mix(0.1, theme.colors.grey2, theme.colors.blue1)};
-    border: 1px solid ${({ theme }) => theme.colors.grey2};
-    color: ${({ theme }) => theme.colors.grey4};
+    background-color: ${({ theme }) => mix(0.1, theme.colors.primary, theme.colors.blue1)};
+    border: 1px solid ${({ theme }) => mix(0.5, theme.colors.primary, theme.colors.blue1)};
+    color: ${({ theme }) => theme.colors.primary};
     flex-shrink: 1;
     min-width: 0;
 
@@ -42,6 +42,7 @@ const DismissButton = styled(Button)`
     font-size: 0.875rem;
     padding: 0.25rem;
     height: auto;
+    color: ${({ theme }) => theme.colors.primary};
 
     &:hover:not(:disabled) {
         background-color: transparent;
@@ -58,6 +59,11 @@ const DismissButtonText = styled.span`
 const CloseButton = styled(Button)`
     padding: 0.25rem;
     height: auto;
+    color: ${({ theme }) => theme.colors.primary};
+
+    &:hover:not(:disabled) {
+        background-color: ${({ theme }) => mix(0.3, theme.colors.primary, theme.colors.blue1)};
+    }
 `;
 
 const blurredText = 'To zoom in/out with scroll, click the viewer area.' as const;

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
@@ -88,14 +88,16 @@ export default function ZoomPrompt(props: ZoomPromptProps): React.ReactElement {
         };
     }, [textRef]);
 
-    const style: React.CSSProperties = {
-        pointerEvents: disablePointerEvents ? 'none' : 'all',
-    };
-
     const textContent = props.hasFocus ? focusedText : blurredText;
 
     return (
-        <PromptWrapper onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit} style={style}>
+        <PromptWrapper
+            onMouseEnter={onPanelEnter}
+            onMouseLeave={onPanelExit}
+            style={{
+                pointerEvents: disablePointerEvents ? 'none' : 'all',
+            }}
+        >
             <CloseButton onClick={props.onClose} styling="ghost">
                 <Xmark size="lg" />
             </CloseButton>

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
@@ -14,7 +14,7 @@ interface ZoomPromptProps {
 }
 
 const PromptWrapper = styled.div`
-    padding: 0 0.5rem;
+    padding: 0.25rem 0.5rem;
     background-color: ${({ theme }) => mix(0.1, theme.colors.grey2, theme.colors.blue1)};
     border: 1px solid ${({ theme }) => theme.colors.grey2};
     color: ${({ theme }) => theme.colors.grey4};
@@ -40,13 +40,19 @@ const DismissText = styled.span`
 const DismissButton = styled(Button)`
     background-color: transparent;
     font-size: 0.875rem;
-    flex-shrink: 0;
     padding: 0.25rem;
+    height: auto;
 
     &:hover:not(:disabled) {
         background-color: transparent;
         text-decoration: underline;
     }
+`;
+
+const DismissButtonText = styled.span`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 `;
 
 const CloseButton = styled(Button)`
@@ -90,15 +96,15 @@ export default function ZoomPrompt(props: ZoomPromptProps): React.ReactElement {
 
     return (
         <PromptWrapper onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit} style={style}>
+            <CloseButton onClick={props.onClose} styling="ghost">
+                <Xmark size="lg" />
+            </CloseButton>
             <Tooltip content={textContent} disabled={!showTooltip}>
                 <DismissText ref={textRef}>{textContent}</DismissText>
             </Tooltip>
             <DismissButton onClick={props.onDismiss} styling="ghost">
-                Don&apos;t show again
+                <DismissButtonText>Don&apos;t show again</DismissButtonText>
             </DismissButton>
-            <CloseButton onClick={props.onClose} styling="ghost">
-                <Xmark size="lg" />
-            </CloseButton>
         </PromptWrapper>
     );
 }

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -600,7 +600,7 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
     /**
      * Notify the engine about focus change on the graph canvas
      *
-     * This is used to enable/disable the zoom-on-scroll behaviour
+     * This is used to enable/disable the wheel listener
      *
      * @param isFocused - focus state
      */

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -610,7 +610,7 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
     /**
      * Notify the engine about focus change on the graph canvas
      *
-     * This is used to enable/disable the wheel listener
+     * This is used to enable/disable behaviour depending on focus state, e.g. zoom on wheel
      *
      * @param isFocused - focus state
      */
@@ -621,6 +621,11 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
         this.toggleWheelZoom(isFocused);
     }
 
+    /**
+     * Toggle zoom-on-wheel behaviour
+     *
+     * @param isEnabled - whether to enable or disable wheel zoom
+     */
     public toggleWheelZoom(isEnabled: boolean): void {
         if (isEnabled) {
             this.viewport.wheel();

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -515,17 +515,13 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
         container.appendChild(this.app.view as HTMLCanvasElement);
         this.textureCache = new TextureCache(this.app.renderer);
 
-        this.app.view.addEventListener('wheel', (event) => {
-            event.preventDefault();
-        });
-
         // Create viewport and add it to the app
         this.viewport = new Viewport({
             events: this.app.renderer.events,
         });
 
         // enable viewport features
-        this.viewport.drag().pinch().wheel().decelerate().clampZoom({ maxScale: 2 });
+        this.viewport.drag({ wheel: false }).pinch().decelerate().clampZoom({ maxScale: 2 });
 
         this.viewport.addEventListener('frame-end', () => {
             if (this.viewport.dirty) {
@@ -599,6 +595,32 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
         this.updateStyles();
         this.initialized = true;
         this.resetViewport();
+    }
+
+    /**
+     * Notify the engine about focus change on the graph canvas
+     *
+     * This is used to enable/disable the zoom-on-scroll behaviour
+     *
+     * @param isFocused - focus state
+     */
+    public setFocus(isFocused: boolean): void {
+        if (!isFocused) {
+            this.viewport.plugins.remove('wheel');
+            this.app.view.removeEventListener('wheel', Engine.wheelListener);
+        } else {
+            this.viewport.wheel();
+            this.app.view.addEventListener('wheel', Engine.wheelListener);
+        }
+    }
+
+    /**
+     * Wheel listener which disables the default browser scrolling behaviour
+     *
+     * @param event - mouse wheel event
+     */
+    private static wheelListener(event: WheelEvent): void {
+        event.preventDefault();
     }
 
     /**

--- a/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
@@ -57,6 +57,10 @@ interface UseRenderEngineApi {
      */
     onSetDragMode: (dragMode: DragMode | null) => void;
     /**
+     * Notify the engine about whether the canvas has focus
+     */
+    onSetFocus: (isFocused: boolean) => void;
+    /**
      * Should be called whenever available constraints change
      *
      * @param constraints new set of constraints
@@ -172,6 +176,11 @@ export function useRenderEngine(
         onSetDragMode: (dragMode: DragMode | null) => {
             engine.current.setDragMode(dragMode);
         },
+        onSetFocus: (isFocused: boolean) => {
+            if (engine.current.initialized) {
+                engine.current.setFocus(isFocused);
+            }
+        },
         onUpdateConstraints: (newConstraints: EdgeConstraint[]) => {
             if (engine.current.initialized) {
                 engine.current.updateConstraints(newConstraints);
@@ -188,10 +197,5 @@ export function useRenderEngine(
             }
         },
         useEngineEvent,
-        onSetFocus: (focus: boolean) => {
-            if (engine.current.initialized) {
-                engine.current.setFocus(focus);
-            }
-        },
     };
 }

--- a/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
@@ -93,17 +93,29 @@ interface UseRenderEngineApi {
  * @param constraints initial edge constraints
  * @param zoomThresholds zoom thresholds
  */
-export function useRenderEngine(
-    parentRef: React.MutableRefObject<HTMLElement>,
-    graph: SimulationGraph,
-    layout: GraphLayout,
-    editable: boolean,
-    editorMode: EditorMode,
-    constraints?: EdgeConstraint[],
-    errorHandler?: (error: NotificationPayload) => void,
-    processEdgeStyle?: (edge: PixiEdgeStyle, attributes: SimulationEdge) => PixiEdgeStyle,
-    zoomThresholds?: ZoomThresholds
-): UseRenderEngineApi {
+export function useRenderEngine({
+    parentRef,
+    graph,
+    layout,
+    editable,
+    editorMode,
+    constraints,
+    errorHandler,
+    processEdgeStyle,
+    zoomThresholds,
+    requireFocusToZoom,
+}: {
+    constraints?: EdgeConstraint[];
+    editable: boolean;
+    editorMode: EditorMode;
+    errorHandler?: (error: NotificationPayload) => void;
+    graph: SimulationGraph;
+    layout: GraphLayout;
+    parentRef: React.MutableRefObject<HTMLElement>;
+    processEdgeStyle?: (edge: PixiEdgeStyle, attributes: SimulationEdge) => PixiEdgeStyle;
+    requireFocusToZoom?: boolean;
+    zoomThresholds?: ZoomThresholds;
+}): UseRenderEngineApi {
     const theme = useTheme();
     const engine = React.useRef<Engine>(null);
     const listeners = React.useRef<Partial<EngineEvents>>({});
@@ -118,7 +130,8 @@ export function useRenderEngine(
             constraints,
             zoomThresholds,
             errorHandler,
-            processEdgeStyle
+            processEdgeStyle,
+            requireFocusToZoom
         );
     }
 

--- a/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
@@ -188,5 +188,10 @@ export function useRenderEngine(
             }
         },
         useEngineEvent,
+        onSetFocus: (focus: boolean) => {
+            if (engine.current.initialized) {
+                engine.current.setFocus(focus);
+            }
+        },
     };
 }

--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -25,7 +25,7 @@ title: Changelog
 -   Added `onKeyDown` prop to NumericInput to bubble up keydown events
 -   Added the `onChange` property to the `onChange` callback dependency
 
-## 1.4.3
+## 1.4.3
 
 -   Pinned fortawesome to `~6.4.0`
 


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Users reported frustrations with the current behaviour where the graph zooms when using the mousewheel to scroll by default. While this is mostly fine for large graphs, if the content itself becomes scrollable this can make it difficult to navigate the page.

This PR makes the behaviour disabled by default - the graph now requires clicking on it to enable the wheel scroll behaviour. This is indicated with a grey focus outline (see gif at the bottom)

This behaviour can be changed to restore the previous one, by providing a prop `requireFocusToZoom` set to false.

The first time the user encounters a graph with the new behaviour turned on they will see a prompt on top explaining the behaviour:

![Screenshot 2024-03-06 at 15 01 24](https://github.com/causalens/dara-ui/assets/87647189/337c9c38-f857-49e6-bd20-de904027595a)

Once a graph is focused an outline is displayed and the prompt changes:

![Screenshot 2024-03-06 at 15 01 55](https://github.com/causalens/dara-ui/assets/87647189/a14e21c1-5688-4dec-98a6-618541ad07a8)

The prompt can be dismissed by clicking X or 'Dont show again' which puts an entry in local storage. This is used on first render to check whether to skip displaying the prompt.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Using a simple click listener on the entire graph pane for enabling the feature, and a `useClickOutside` for disabling it. That in turn adds or removes the wheel plugin from the pixi viewport, alongside a wheel listener on the canvas.

Extended the overlay to include a 'top center' component to fit the new zoom prompt. The prompt uses a resize observer to detect whether it's currently displaying an ellipsis; when that's the case, a tooltip is enabled to show the full message on hover.

I've also changed the engine hook arguments to take an object rather than a list of args as it was getting pretty long.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally in storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->


https://github.com/causalens/dara-ui/assets/87647189/7db001e6-30e7-4faf-8d61-e4cbfb410a65


https://github.com/causalens/dara-ui/assets/87647189/373c979b-7be0-47bb-90ed-ee81f06a72e5



See smaller screen ellipsis behaviour below. Note I did not handle graph sizes below a certain point, it was deemed not to be important enough to handle as it's a pretty rare scenario and it's just a one time popup.

https://github.com/causalens/dara-ui/assets/87647189/71f21cfa-2cfd-4ff1-9188-6619db4b4634

