### PR TITLE
Improvement: DO-2661 recalculate layout on pane resize

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Graph layout is now recalculated after every resize of the graph window detected, preventing scenarios where the initially computed layout is not optimal for the new window size due to a sudden graph pane resize
+
 ## 1.6.0
 
 -   Updated the type of `additionalLegends` to also allow defining nodes
@@ -13,8 +17,8 @@ title: Changelog
 
 ## 1.5.1
 
--   Added `simultaneousEdgeNodeSelection` prop to `CausalGraphEditor` which when set to true allows for both an edge and a node to be selected simultaneously. 
--   If `TimeSeriesCausalGraph` object is passed to `CausalGraphEditor` and no tiers are defines, it now uses `time_lag` and `variable_name` to define the `order_nodes_by` and `group` respectively. 
+-   Added `simultaneousEdgeNodeSelection` prop to `CausalGraphEditor` which when set to true allows for both an edge and a node to be selected simultaneously.
+-   If `TimeSeriesCausalGraph` object is passed to `CausalGraphEditor` and no tiers are defines, it now uses `time_lag` and `variable_name` to define the `order_nodes_by` and `group` respectively.
 -   Fixed an issue where we couldn't set `tiers` to the `PlanarLayoutBuilder`.
 
 ## 1.5.0

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -558,8 +558,10 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
             this.app.resize();
             this.viewport.resize(this.container.clientWidth, this.container.clientHeight);
             this.background.updatePosition(this.container);
-            this.updateGraphVisibility();
-            this.requestRender();
+
+            // keep layout in sync - invoke a debounced update to only update it once resizing is done rather than
+            // re-running a potentially expensive layout computation on every resize event
+            this.debouncedUpdateLayout();
         });
 
         this.resizeObserver.observe(this.container);


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

There are scenarios where with layout shifts on a page (i.e. a py_component rendering) sometimes the graph has to resize itself after its initial layout computation. This causes the original layout to be wrong which can be annoying for users.

As a compromise the solution here is to recalculate the layout after a resize was detected. While this will potentially have destructive effect on a hand-crafted layout (i.e. after user shuffled nodes arounds manually and something shifted, the recalculate button will effectively be clicked for them), this should not a a common scenario and more often than not will be an improvement to the UX. If the downside becomes severe we can prioritize features such as being able to save and restore a custom layout.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

There was already a resize observer attached to the graph, responsible for resizing the background. It was simply extended to also invoke a layout update.

We're using a debounced update to prevent us from having to run a potentially expensive calculation multiple times a second while the graph is being resized.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->

https://github.com/causalens/dara-ui/assets/87647189/f646c3cc-1ee6-453e-94d6-7b3d3b3132f1

