### PR TITLE
Fix: DO-2692 causal graph tooltip quirks with visibility

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -6,6 +6,7 @@ title: Changelog
 
 -   Zooming the graph with mousewheel is now disabled by default and requires first focusing the graph by clicking on it. This is to prevent accidental zooming when scrolling through the page.
 The previous behaviour can be restored by setting `requireFocusToZoom` prop to true.
+-   Fixed issues with graph viewer tooltip appearing even over parts of the graph which are not currently visible on the screen
 
 ## 1.6.0
 

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -587,6 +587,16 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
 
     const [showFrameButtons, setShowFrameButtons] = useState(false);
 
+    function onMouseEnter(): void {
+        setShowFrameButtons(true);
+    }
+
+    function onMouseLeave(): void {
+        setShowFrameButtons(false);
+        // ensure tooltip is hidden when mouse leaves
+        setTooltipContent(null);
+    }
+
     const { nextNode, prevNode } = useIterateNodes(selectedNode, setSelectedNode, state);
     const { nextEdge, prevEdge } = useIterateEdges(selectedEdge, setSelectedEdge, state);
 
@@ -649,10 +659,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
         >
             <PointerContext.Provider value={{ disablePointerEvents: isDragging, onPanelEnter, onPanelExit }}>
                 <GraphPane $hasFocus={hasFocus} onClick={() => onPaneFocus(true)} ref={paneRef} style={props.style}>
-                    <Graph
-                        onMouseEnter={() => setShowFrameButtons(true)}
-                        onMouseLeave={() => setShowFrameButtons(false)}
-                    >
+                    <Graph onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
                         <Overlay
                             bottomLeft={
                                 <Legend

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -18,6 +18,7 @@ import debounce from 'lodash/debounce';
 import noop from 'lodash/noop';
 import { useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
+import { GetReferenceClientRect } from 'tippy.js';
 
 import styled, { useTheme } from '@darajs/styled-components';
 import { Tooltip } from '@darajs/ui-components';
@@ -411,7 +412,8 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
         }
     }
 
-    const { tooltipContent, setTooltipContent, tooltipRef } = useGraphTooltip(paneRef);
+    const tooltipRef = React.useRef<GetReferenceClientRect>(null);
+    const { tooltipContent, setTooltipContent } = useGraphTooltip(paneRef, tooltipRef);
 
     // keep track of when a drag action is happening
     const [isDragging, setIsDragging] = useState(false);

--- a/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
@@ -169,7 +169,7 @@ Collapsed.args = {
 
 export const Scrollable = (args: CausalGraphEditorProps): JSX.Element => {
     return (
-        <div style={{ height: '500px', display: 'flex', overflow: 'auto', flexDirection: 'column' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', height: '500px', overflow: 'auto' }}>
             {Array(50)
                 .fill(0)
                 .map((_, idx) => (

--- a/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
@@ -19,7 +19,10 @@ import Graph from 'graphology';
 import clusters from 'graphology-generators/random/clusters';
 import deepCopy from 'lodash/cloneDeep';
 import set from 'lodash/set';
+import * as React from 'react';
 import { useEffect, useState } from 'react';
+
+import { Accordion } from '@darajs/ui-components';
 
 import { FRAUD, SHIPPED_UNITS } from '../../tests/mocks/graphs';
 import {
@@ -140,6 +143,50 @@ Interactive.args = {
         },
     ],
     editable: true,
+    graphLayout: PlanarLayout.Builder.build(),
+};
+
+/**
+ * Tests scenario where the graph is collapsed, to ensure e.g. tooltips don't bleed out of the container
+ */
+export const Collapsed = (args: CausalGraphEditorProps): JSX.Element => {
+    return (
+        <Accordion
+            items={[
+                {
+                    content: <CausalGraphViewerComponent {...args} style={{ height: '300px' }} />,
+                    label: 'Graph',
+                },
+            ]}
+        />
+    );
+};
+Collapsed.args = {
+    editable: true,
+    graphData: causalGraph,
+    graphLayout: PlanarLayout.Builder.build(),
+};
+
+export const Scrollable = (args: CausalGraphEditorProps): JSX.Element => {
+    return (
+        <div style={{ height: '500px', display: 'flex', overflow: 'auto', flexDirection: 'column' }}>
+            {Array(50)
+                .fill(0)
+                .map((_, idx) => (
+                    <span key={idx}>{idx}</span>
+                ))}
+            <CausalGraphViewerComponent {...args} style={{ minHeight: '500px' }} />
+            {Array(50)
+                .fill(0)
+                .map((_, idx) => (
+                    <span key={idx}>{idx}</span>
+                ))}
+        </div>
+    );
+};
+Scrollable.args = {
+    editable: true,
+    graphData: causalGraph,
     graphLayout: PlanarLayout.Builder.build(),
 };
 

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
@@ -104,13 +104,25 @@ export default function ZoomPrompt(props: ZoomPromptProps): React.ReactElement {
                 pointerEvents: disablePointerEvents ? 'none' : 'all',
             }}
         >
-            <CloseButton onClick={props.onClose} styling="ghost">
+            <CloseButton
+                onClick={() => {
+                    onPanelExit();
+                    props.onClose();
+                }}
+                styling="ghost"
+            >
                 <Xmark size="lg" />
             </CloseButton>
             <Tooltip content={textContent} disabled={!showTooltip}>
                 <DismissText ref={textRef}>{textContent}</DismissText>
             </Tooltip>
-            <DismissButton onClick={props.onDismiss} styling="ghost">
+            <DismissButton
+                onClick={() => {
+                    onPanelExit();
+                    props.onDismiss();
+                }}
+                styling="ghost"
+            >
                 <DismissButtonText>Don&apos;t show again</DismissButtonText>
             </DismissButton>
         </PromptWrapper>

--- a/packages/ui-causal-graph-editor/src/shared/use-graph-tooltip.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-graph-tooltip.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+
+import usePaneVisibility from './use-pane-visibility';
+import { GetReferenceClientRect } from 'tippy.js';
+
+export default function useGraphTooltip(pane: React.RefObject<HTMLElement>): {
+    setTooltipContent: (content: React.ReactNode) => void;
+    tooltipContent: React.ReactNode;
+    tooltipRef: React.MutableRefObject<GetReferenceClientRect>;
+} {
+    const tooltipRef = React.useRef<GetReferenceClientRect>(null);
+    const [tooltipContent, setTooltipContent] = React.useState<React.ReactNode>(null);
+
+    // force tooltip to hide when the pane becomes invisible
+    const onPaneVisibilityChange = React.useCallback((isVisible: boolean) => {
+        if (!isVisible) {
+            setTooltipContent(null);
+        }
+    }, []);
+
+    // reset tooltip when the pane becomes invisible
+    React.useEffect(() => {
+        const handler = (): void => {
+            if (document.visibilityState !== 'visible') {
+                setTooltipContent(null);
+            }
+        };
+
+        document.addEventListener('visibilitychange', handler);
+
+        return () => {
+            document.removeEventListener('visibilitychange', handler);
+        };
+    }, []);
+
+    // Keep track of whether the graph pane is visible
+    const { isRectVisible } = usePaneVisibility(pane, onPaneVisibilityChange);
+
+    /**
+     * Show a tooltip at the current mouse position
+     *
+     * Makes sure the tooltip is only shown when the pane is visible
+     *
+     * @param content the content to show in the tooltip
+     */
+    function showTooltip(content: React.ReactNode): void {
+        // NOTE: This is technically async but will resolve immediately as it's resolved
+        // in response to IntersectionObserver callback, which is guaranteed to fire
+        // the next render cycle
+        isRectVisible(tooltipRef.current()).then((isVisible) => {
+            setTooltipContent(isVisible ? content : null);
+        });
+    }
+
+    return {
+        setTooltipContent: showTooltip,
+        tooltipContent,
+        tooltipRef,
+    };
+}

--- a/packages/ui-causal-graph-editor/src/shared/use-graph-tooltip.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-graph-tooltip.tsx
@@ -1,14 +1,23 @@
 import * as React from 'react';
-
-import usePaneVisibility from './use-pane-visibility';
 import { GetReferenceClientRect } from 'tippy.js';
 
-export default function useGraphTooltip(pane: React.RefObject<HTMLElement>): {
+import usePaneVisibility from './use-pane-visibility';
+
+/**
+ * Helper hook to manage a tooltip for the graph pane
+ *
+ * Handles showing and hiding the tooltip based on the visibility of the pane
+ *
+ * @param pane - pane to observe visibility of
+ * @param tooltipRef - ref to the tooltip position
+ */
+export default function useGraphTooltip(
+    pane: React.RefObject<HTMLElement>,
+    tooltipRef: React.MutableRefObject<GetReferenceClientRect>
+): {
     setTooltipContent: (content: React.ReactNode) => void;
     tooltipContent: React.ReactNode;
-    tooltipRef: React.MutableRefObject<GetReferenceClientRect>;
 } {
-    const tooltipRef = React.useRef<GetReferenceClientRect>(null);
     const [tooltipContent, setTooltipContent] = React.useState<React.ReactNode>(null);
 
     // force tooltip to hide when the pane becomes invisible
@@ -44,6 +53,16 @@ export default function useGraphTooltip(pane: React.RefObject<HTMLElement>): {
      * @param content the content to show in the tooltip
      */
     function showTooltip(content: React.ReactNode): void {
+        // if simply setting the content to null, don't bother with the visibility check
+        if (!content) {
+            setTooltipContent(null);
+            return;
+        }
+
+        if (content === tooltipContent) {
+            return;
+        }
+
         // NOTE: This is technically async but will resolve immediately as it's resolved
         // in response to IntersectionObserver callback, which is guaranteed to fire
         // the next render cycle
@@ -55,6 +74,5 @@ export default function useGraphTooltip(pane: React.RefObject<HTMLElement>): {
     return {
         setTooltipContent: showTooltip,
         tooltipContent,
-        tooltipRef,
     };
 }

--- a/packages/ui-causal-graph-editor/src/shared/use-pane-visibility.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-pane-visibility.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+
+/**
+ * Hook to observe the visibility of a pane. Accepts a callback to call when the visibility changes,
+ * and returns a function to check whether a given domRect is visible within the pane.
+ *
+ * @param pane - pane to observe visibility of
+ * @param onVisibilityChange - callback to call when visibility changes
+ */
+export default function usePaneVisibility(
+    pane: React.RefObject<HTMLElement>,
+    onVisibilityChange: (isVisible: boolean) => void
+): { isRectVisible: (domRect: DOMRect) => Promise<boolean> } {
+    // Keep track of whether the graph pane is visible
+    const isPaneVisible = React.useRef(false);
+
+    React.useEffect(() => {
+        const observer = new IntersectionObserver((entries) => {
+            for (const entry of entries) {
+                isPaneVisible.current = entry.isIntersecting;
+                onVisibilityChange(isPaneVisible.current);
+            }
+        });
+
+        observer.observe(pane.current);
+
+        return () => {
+            observer.disconnect();
+        };
+    }, [onVisibilityChange, pane]);
+
+    /**
+     * Check whether a given domRect is visible on screen, i.e. within a visible part of the pane
+     *
+     * @param domRect - dom rect to check visibility of
+     * @returns whether the given domRect is visible within the pane
+     */
+    async function isRectVisible(domRect: DOMRect): Promise<boolean> {
+        // pane is not visible at all (i.e. collapsed / scrolled out of view)
+        if (!isPaneVisible.current) {
+            return false;
+        }
+
+        // otherwise create a new one-off observer to check whether given domRect position is on screen
+        // NOTE: we're relying on the fact that as per the IntersectionObserver spec, the callback is immediately invoked on observe
+        let resolve: (entries: IntersectionObserverEntry | null) => void;
+        const recordPromise = new Promise<IntersectionObserverEntry | null>((r) => {
+            resolve = r;
+        });
+        const observer = new IntersectionObserver((entries) => {
+            resolve(entries[0]);
+        });
+        observer.observe(pane.current);
+
+        // create a timeout promise to race with to ensure the promise resolves in a reasonable time
+        const timeoutPromise = new Promise<null>((r) => setTimeout(r, 500, null));
+
+        const rec = await Promise.race([recordPromise, timeoutPromise]);
+
+        // make sure to disconnect the observer
+        observer.disconnect();
+
+        // timeout occurred
+        if (!rec) {
+            return false;
+        }
+
+        // offscreen
+        if (rec.intersectionRatio <= 0) {
+            return false;
+        }
+
+        // once the observer produces a record, check if the domRect is within the intersectionRect
+        // i.e. it's on a visible part of the pane
+        return (
+            rec.intersectionRect.top <= domRect.top &&
+            rec.intersectionRect.bottom >= domRect.bottom &&
+            rec.intersectionRect.left <= domRect.left &&
+            rec.intersectionRect.right >= domRect.right
+        );
+    }
+
+    return {
+        isRectVisible,
+    };
+}

--- a/packages/ui-causal-graph-editor/src/shared/use-pane-visibility.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-pane-visibility.tsx
@@ -70,7 +70,13 @@ export default function usePaneVisibility(
             return false;
         }
 
-        // once the observer produces a record, check if the domRect is within the intersectionRect
+        // fully on screen - assume visible
+        if (rec.intersectionRatio === 1) {
+            return true;
+        }
+
+        // otherwise, partially on screen
+        // check if the domRect is within the intersectionRect
         // i.e. it's on a visible part of the pane
         return (
             rec.intersectionRect.top <= domRect.top &&


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

The original causal graph viewer tooltip implementation did not account for the viewer being out of view due to overflowing in e.g. a scrollable container or a collapse/accordion style component.
This resulted in the tooltips being displayed in seemingly random places, when hovering over where the graph would be if it wasn't for the fact that it's currently hidden. There were also other quirks where the tooltip wouldn't disappear correctly when moving the mouse out of the graph.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Implemented few fixes:
1. Tooltip is now explicitly set to null `onMouseLeave` of the graph pane - this fixes scenarios where a node is right on the border of the graph view, and previously moving the mouse out of the view kept the tooltip on. Also added a `contentvisibility` listener so focusing out of the window also hides the active tooltip.

https://github.com/causalens/dara-ui/assets/87647189/e000d373-78d7-410c-b0e4-a720477313c6



2. Added a continuous IntersectionObserver which observes whether the graph pane is currently visible (at all, meaning if at least a few pixels of it are in the viewport and visible); this is used when attempting to set tooltip content to short-circuit and prevent them from being displayed on e.g. graphs within a collapsed accordion.

https://github.com/causalens/dara-ui/assets/87647189/3753f9bd-2f58-46c8-88ea-f6e388a7eebd

(this used to show tooltips over the hidden graph)


3. When attempting to show a tooltip and the above check succeeded, we perform a one-time check spawning a new intersection observer to check whether the tooltip would appear over a visible part of the graph. This can't use the previous continuous IntersectionObserver as that one only fires events when the graph first moves in or out of view, and we need more accurate information on its position. I didn't find a better way than spawning a new observer.
If the logic detects a partially visible graph, we check the tooltip's position - whether it's over the visible part of the graph.

https://github.com/causalens/dara-ui/assets/87647189/7f930f2c-83cf-4fc4-93f6-a390106c60cf



Extracted the tooltip-related logic into separate hooks not to pollute the main graph file further.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually, added two stories to test a scrollable and a collapsible scenario

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->