### PR TITLE
Fix: DO-2740 chat messages do not wrap the text

### DIFF
--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where if a word was too long, such as in an url, the `Chat` message would overflow instead of wrap.
+
 ## 1.7.1
 
 -   Added a new `Chat` component.

--- a/packages/ui-components/src/chat/message.tsx
+++ b/packages/ui-components/src/chat/message.tsx
@@ -71,7 +71,7 @@ const MessageBody = styled.div`
     display: flex;
     width: 100%;
     color: ${(props) => props.theme.colors.text};
-    word-break: break-word; 
+    overflow-wrap: break-word; 
 `;
 
 const DeleteIcon = styled(Trash)`

--- a/packages/ui-components/src/chat/message.tsx
+++ b/packages/ui-components/src/chat/message.tsx
@@ -71,7 +71,7 @@ const MessageBody = styled.div`
     display: flex;
     width: 100%;
     color: ${(props) => props.theme.colors.text};
-    overflow-wrap: break-word; 
+    overflow-wrap: break-word;
 `;
 
 const DeleteIcon = styled(Trash)`

--- a/packages/ui-components/src/chat/message.tsx
+++ b/packages/ui-components/src/chat/message.tsx
@@ -71,6 +71,7 @@ const MessageBody = styled.div`
     display: flex;
     width: 100%;
     color: ${(props) => props.theme.colors.text};
+    word-break: break-word; 
 `;
 
 const DeleteIcon = styled(Trash)`


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
When pasting an url in chat it would overflow the container instead or wrapping

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Added `overflow-wrap: break-word;` so that if a word is too long to fit in one line alone it will break. This is useful in the case of for example pasting urls.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->