### PR TITLE
Fix: DO-2743 chat message adding a n at the end on reload

### DIFF
--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 -   Fixed an issue where if a word was too long, such as in an url, the `Chat` message would overflow instead of wrap.
+-   Fixed an issue where if a newline character was added to a comment, on subsequent reloads it would show '/n' in the message.
 
 ## 1.7.1
 

--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -5,7 +5,7 @@ title: Changelog
 ## NEXT
 
 -   Fixed an issue where if a word was too long, such as in an url, the `Chat` message would overflow instead of wrap.
--   Fixed an issue where if a newline character was added to a comment, on subsequent reloads it would show '/n' in the message.
+-   Fixed an issue where in `Chat` component if a newline character was added to a comment, on subsequent reloads it would show '/n' in the message.
 
 ## 1.7.1
 

--- a/packages/ui-components/src/chat/chat.tsx
+++ b/packages/ui-components/src/chat/chat.tsx
@@ -146,7 +146,8 @@ function Chat(props: ChatProps): JSX.Element {
             // Create a new message
             const newMessage = {
                 id: nanoid(),
-                message: reply,
+                // remove any /n and trailing whitespace
+                message: reply.replace(/\n/g, ' ').replace(/\s+$/, ''),
                 timestamp: getFormattedTimestamp(),
             };
             const newMessages = [...localMessages, newMessage];

--- a/packages/ui-components/src/chat/chat.tsx
+++ b/packages/ui-components/src/chat/chat.tsx
@@ -147,7 +147,7 @@ function Chat(props: ChatProps): JSX.Element {
             const newMessage = {
                 id: nanoid(),
                 // remove any /n and trailing whitespace
-                message: reply.replace(/\n/g, ' ').replace(/\s+$/, ''),
+                message: reply.replace(/\n/g, ' ').trim(),
                 timestamp: getFormattedTimestamp(),
             };
             const newMessages = [...localMessages, newMessage];

--- a/packages/ui-components/src/chat/message.tsx
+++ b/packages/ui-components/src/chat/message.tsx
@@ -132,7 +132,7 @@ function MessageComponent(props: MessageProps): JSX.Element {
             return;
         }
         // remove any /n and trailing whitespace
-        const newMessage = { ...localMessage, message: editMessage.replace(/\n/g, ' ').replace(/\s+$/, '') };
+        const newMessage = { ...localMessage, message: editMessage.replace(/\n/g, ' ').trim() };
 
         props?.onChange(newMessage);
         setLocalMessage(newMessage);

--- a/packages/ui-components/src/chat/message.tsx
+++ b/packages/ui-components/src/chat/message.tsx
@@ -131,10 +131,13 @@ function MessageComponent(props: MessageProps): JSX.Element {
         if (editMessage === localMessage.message) {
             return;
         }
-        const newMessage = { ...localMessage, message: editMessage };
+        // remove any /n and trailing whitespace
+        const newMessage = { ...localMessage, message: editMessage.replace(/\n/g, ' ').replace(/\s+$/, '') };
 
         props?.onChange(newMessage);
         setLocalMessage(newMessage);
+        // need to reset the textarea message to the message without the /n and trailing whitespace
+        setEditMessage(newMessage.message);
         setEditMode(false);
     };
 


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
It was noted that after page refreshes any enters entered would show as \n and then `\\n`etc.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
For now I am just removing any \n and trailing white space for messages. In the future we will go back into this to display these properly.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on storybook logging the message values to see if any \n were adequately removed

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->