### PR TITLE
Fix: graph viewport resize error

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where graph rendering would enter an infinite loop and cause crashes in some circumstances
+
 ## 1.7.0
 
 -   Graph layout is now recalculated after every resize of the graph window detected, preventing scenarios where the initially computed layout is not optimal for the new window size due to a sudden graph pane resize

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -341,13 +341,20 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
         const worldWidth = graphWidth + WORLD_PADDING * 2;
         const worldHeight = graphHeight + WORLD_PADDING * 2;
 
-        this.viewport.resize(this.container.clientWidth, this.container.clientHeight, worldWidth, worldHeight);
+        try {
+            this.viewport.resize(this.container.clientWidth, this.container.clientHeight, worldWidth, worldHeight);
 
-        this.viewport.setZoom(1);
-        this.viewport.center = graphCenter;
-        this.viewport.fit(true);
+            this.viewport.setZoom(1);
+            this.viewport.center = graphCenter;
+            this.viewport.fit(true);
 
-        this.updateGraphVisibility();
+            this.updateGraphVisibility();
+        } catch (err) {
+            // Resizing can sometimes fail if e.g the canvas are temporarily not accessible due to an ongoing layout shift
+            // We're simply ignoring this error as it's not critical and a future reset will likely succeed on next layout update
+            // eslint-disable-next-line no-console
+            console.error('Error resetting viewport', err);
+        }
     }
 
     /**

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -1302,7 +1302,7 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
     /**
      * Recompute the layout and apply it
      */
-    private async updateLayout(): Promise<void> {
+    private async updateLayout(retry: boolean = false): Promise<void> {
         // Cleanup previous layout
         this.onCleanup?.();
 
@@ -1318,6 +1318,12 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
 
             this.setLayout(layout, edgePoints);
         } catch (e) {
+            if (retry) {
+                // If we're already retrying, we should stop here to avoid infinite loops
+                // This should never happen but is a safety measure
+                console.error('Layout failed even after retrying', e);
+                return;
+            }
             // TODO: remove console below once we have a nice way of showing more info with the stack trace
             // eslint-disable-next-line no-console
             console.error(e);
@@ -1348,7 +1354,7 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
                 (this.layout as GraphLayoutWithTiers).orientation = orientation;
             }
 
-            this.updateLayout();
+            this.updateLayout(true);
         }
     }
 


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

There was a reported issue where sometimes the graph viewer could crash the browser tab. I managed to reproduce the issue and it is caused by an infinite loop in the layout update logic. I suspect this has been caused by the recent extra layout updates triggered on layout shifts, added in #81. 

The layout computation logic for certain layouts can error, e.g. for PlanarLayout which has certain restrictions on the format of the graph (must be a DAG) etc. Because of that the update logic is wrapped in a `try/catch` and falls back to resetting the graph to FCose which is known to be stable and not crash (to best of our knowledge):

```typescript
// simplified code
    private async updateLayout(): Promise<void> {
        // ...
        this.onCleanup?.();

        try {
            // compute layout
            const { layout, edgePoints, onStartDrag, onEndDrag, onCleanup, onMove, onAddNode, onAddEdge } =
                await this.layout.applyLayout(this.graph, (l, e) => this.setLayout(l, e, false));
            // ...

            this.setLayout(layout, edgePoints);
        } catch (e) {
           
            console.error(e);
            // call error handler
            this.errorHandler({
                key: 'LayoutError',
                message: e.message,
                status: Status.WARNING,
                title: 'Defaulting to Fcose Layout',
            });

            // ...

            // Rebuild the layout to use FCose instead
            this.layout = FcoseLayout.Builder.nodeSize(this.layout.nodeSize)
                .nodeFontSize(this.layout.nodeFontSize)
                .build();

            // ...

            // call update again
            this.updateLayout();
        }
    }

```

This code was not written very defensively, and it can enter update loops if the retry of `updateLayout` errors again. This was not the case in the past however the part which does error in some circumstances is `setLayout` which invokes `resetViewport`:
![Screenshot 2024-03-25 at 14 05 58](https://github.com/causalens/dara-ui/assets/87647189/49d1fc5e-234f-4a39-9479-83a8b579b855)

I've traced the code through with a debugger and it's caused by one of the viewport plugins trying to compute its parent size and `this.parent.transform` being null down the chain. I suspect this is caused during a layout shift as it's only occurs in certain cases. Ignoring the error is fine, I've tested it and future recomputations and viewport resets succeed even after this error occurs.

Therefore, the proposed fix is twofold:
1) Introduce a safeguard measure in `updateLayout` to disallow infinite loops from occurring. This is implemented with a simple `retry` boolean param which is set to `true` if invoking the layout update with a fallback. In this case the fallback logic is skipped which breaks out of the loop.

2) Add an explicit `try/catch` within `updateViewport` which is the source of the error. As proven empirically the error is safe to ignore and does not 'break' the state of the renderer or graph permanently. 

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually by reproducing the bug and applying the fix locally, ensuring the bug doesn't occur anymore

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->