### PR TITLE
Fix: DO-2772 edges added as undirected in editable mode

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -4,7 +4,8 @@ title: Changelog
 
 ## NEXT
 
--   Fixed an issue where graph rendering would enter an infinite loop and cause crashes in some circumstances
+-   Fixed an issue where graph rendering would enter an infinite loop and cause crashes in some circumstances.
+-   Fixed an issue where if `EditorMode` was not defined edges were always added as undirected.
 
 ## 1.7.0
 

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -42,7 +42,7 @@ import {
 } from '@shared/editor-overlay';
 import ZoomPrompt from '@shared/editor-overlay/zoom-prompt';
 import useGraphTooltip from '@shared/use-graph-tooltip';
-import { getTooltipContent, isDag, willCreateCycle } from '@shared/utils';
+import { getTooltipContent, willCreateCycle } from '@shared/utils';
 
 import {
     CausalGraph,
@@ -172,10 +172,6 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
         props.availableInputs
     );
 
-    const [editorMode] = useState(
-        () => props.editorMode ?? (isDag(state.graph) ? EditorMode.DEFAULT : EditorMode.PAG_VIEWER)
-    );
-
     const [error, setError] = useState(null);
     const handleError = (e: NotificationPayload): void => {
         setError(e);
@@ -195,7 +191,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
     } = useRenderEngine({
         constraints: props.initialConstraints,
         editable: props.editable,
-        editorMode,
+        editorMode: state.editorMode,
         errorHandler: handleError,
         graph: state.graph,
         layout,
@@ -282,7 +278,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
         useEdgeConstraintEncoder(props.initialConstraints, props.onEdgeConstraintsUpdate);
 
     const selectedConstraint = useMemo(() => {
-        if (editorMode === EditorMode.EDGE_ENCODER && selectedEdge) {
+        if (state.editorMode === EditorMode.EDGE_ENCODER && selectedEdge) {
             const [source, target] = selectedEdge;
 
             // Find constraint with either matching or reversed source/target
@@ -290,7 +286,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
                 (c) => (c.source === source && c.target === target) || (c.source === target && c.target === source)
             );
         }
-    }, [editorMode, selectedEdge, constraints]);
+    }, [state.editorMode, selectedEdge, constraints]);
 
     // deletion
 
@@ -306,7 +302,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
 
     function onConfirmRemoveEdge(): void {
         // In encoder mode, remove related constraint
-        if (editorMode === EditorMode.EDGE_ENCODER) {
+        if (state.editorMode === EditorMode.EDGE_ENCODER) {
             onRemoveConstraint();
         }
 
@@ -358,7 +354,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
             return;
         }
 
-        if (editorMode === EditorMode.EDGE_ENCODER) {
+        if (state.editorMode === EditorMode.EDGE_ENCODER) {
             const [source, target] = edge;
             addConstraint(source, target);
         }
@@ -407,7 +403,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
         api.updateEdgeType(selectedEdge, EdgeType.DIRECTED_EDGE);
 
         if (reverse) {
-            if (editorMode === EditorMode.EDGE_ENCODER) {
+            if (state.editorMode === EditorMode.EDGE_ENCODER) {
                 onReverseConstraint();
             }
 
@@ -476,7 +472,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
         const sourceLabel = sourceNodeAttributes['meta.rendering_properties.label'] ?? sourceNodeAttributes.id;
         const targetLabel = targetNodeAttributes['meta.rendering_properties.label'] ?? targetNodeAttributes.id;
 
-        const tooltipArrow = editorMode === EditorMode.DEFAULT ? '➜' : '-';
+        const tooltipArrow = state.editorMode === EditorMode.DEFAULT ? '➜' : '-';
 
         const edgeTooltipContent = getTooltipContent(
             `${sourceLabel} ${tooltipArrow} ${targetLabel}`,
@@ -634,7 +630,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
     if (selectedEdge) {
         contentSelected = state.graph.hasEdge(selectedEdge[0], selectedEdge[1]);
         panelTitle = 'Edge';
-    } else if (selectedNode && editorMode !== EditorMode.EDGE_ENCODER) {
+    } else if (selectedNode && state.editorMode !== EditorMode.EDGE_ENCODER) {
         contentSelected = state.graph.hasNode(selectedNode);
         panelTitle = 'Node';
     }
@@ -656,7 +652,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
                 disableLatentNodeAdd: props.disableLatentNodeAdd,
                 disableNodeRemoval: props.disableNodeRemoval,
                 editable: props.editable,
-                editorMode,
+                editorMode: state.editorMode,
                 onNotify: props.onNotify,
                 verboseDescriptions: props.verboseDescriptions,
             }}
@@ -667,7 +663,11 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
                         <Overlay
                             bottomLeft={
                                 <Legend
-                                    listItems={getLegendData(props.defaultLegends, editorMode, props.additionalLegends)}
+                                    listItems={getLegendData(
+                                        props.defaultLegends,
+                                        state.editorMode,
+                                        props.additionalLegends
+                                    )}
                                 />
                             }
                             onDelete={onDelete}

--- a/packages/ui-causal-graph-editor/src/shared/causal-graph-store.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/causal-graph-store.tsx
@@ -55,6 +55,7 @@ interface AddLatentNodeAction {
 
 interface InitGraphAction {
     graph: SimulationGraph;
+    editorMode: EditorMode;
     type: GraphActionType.INIT_GRAPH;
 }
 
@@ -180,6 +181,7 @@ export const GraphReducer: Reducer<GraphState, GraphAction> = (state, action) =>
 
         case GraphActionType.INIT_GRAPH: {
             draft.graph = action.graph;
+            draft.editorMode = action.editorMode;
 
             break;
         }

--- a/packages/ui-causal-graph-editor/src/shared/causal-graph-store.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/causal-graph-store.tsx
@@ -18,7 +18,6 @@ import { IPointData } from 'pixi.js';
 import { Reducer } from 'react';
 
 import { EdgeType, EditorMode, GraphState, SimulationEdge, SimulationGraph, VariableType } from '../types';
-import { isDag } from './utils';
 
 export enum GraphActionType {
     ACCEPT_EDGE = 'ACCEPT_EDGE',
@@ -139,10 +138,8 @@ export const GraphReducer: Reducer<GraphState, GraphAction> = (state, action) =>
         }
 
         case GraphActionType.ADD_EDGE: {
-            const editorMode = draft.editorMode ?? (isDag(draft.graph) ? EditorMode.DEFAULT : EditorMode.PAG_VIEWER);
-
             const edgeType =
-                [EditorMode.DEFAULT, EditorMode.RESOLVER].includes(editorMode) ?
+                [EditorMode.DEFAULT, EditorMode.RESOLVER].includes(state.editorMode) ?
                     EdgeType.DIRECTED_EDGE
                 :   EdgeType.UNDIRECTED_EDGE;
 

--- a/packages/ui-causal-graph-editor/src/shared/causal-graph-store.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/causal-graph-store.tsx
@@ -145,7 +145,6 @@ export const GraphReducer: Reducer<GraphState, GraphAction> = (state, action) =>
                 [EditorMode.DEFAULT, EditorMode.RESOLVER].includes(editorMode) ?
                     EdgeType.DIRECTED_EDGE
                 :   EdgeType.UNDIRECTED_EDGE;
-            
 
             const attributes: SimulationEdge = {
                 edge_type: edgeType,

--- a/packages/ui-causal-graph-editor/src/shared/causal-graph-store.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/causal-graph-store.tsx
@@ -18,6 +18,7 @@ import { IPointData } from 'pixi.js';
 import { Reducer } from 'react';
 
 import { EdgeType, EditorMode, GraphState, SimulationEdge, SimulationGraph, VariableType } from '../types';
+import { isDag } from './utils';
 
 export enum GraphActionType {
     ACCEPT_EDGE = 'ACCEPT_EDGE',
@@ -138,10 +139,13 @@ export const GraphReducer: Reducer<GraphState, GraphAction> = (state, action) =>
         }
 
         case GraphActionType.ADD_EDGE: {
+            const editorMode = draft.editorMode ?? (isDag(draft.graph) ? EditorMode.DEFAULT : EditorMode.PAG_VIEWER);
+
             const edgeType =
-                [EditorMode.DEFAULT, EditorMode.RESOLVER].includes(draft.editorMode) ?
+                [EditorMode.DEFAULT, EditorMode.RESOLVER].includes(editorMode) ?
                     EdgeType.DIRECTED_EDGE
                 :   EdgeType.UNDIRECTED_EDGE;
+            
 
             const attributes: SimulationEdge = {
                 edge_type: edgeType,

--- a/packages/ui-causal-graph-editor/src/shared/use-causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-causal-graph-editor.tsx
@@ -108,8 +108,12 @@ export default function useCausalGraphEditor(
             !isEqual(lastParentData.current.nodes, graphData.nodes) ||
             !isEqual(lastParentData.current.edges, graphData.edges)
         ) {
+            const parsedGraph = causalGraphParser(graphData, availableInputs, state.graph);
+            const newEditorMode = editorMode ?? (isDag(parsedGraph) ? EditorMode.DEFAULT : EditorMode.PAG_VIEWER);
+
             dispatch({
                 graph: causalGraphParser(graphData, availableInputs, state.graph),
+                editorMode: newEditorMode,
                 type: GraphActionType.INIT_GRAPH,
             });
         }

--- a/packages/ui-causal-graph-editor/src/shared/use-causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-causal-graph-editor.tsx
@@ -21,6 +21,7 @@ import { CausalGraph, EditorMode, GraphState } from '../types';
 import { GraphActionCreators, GraphActionType, GraphReducer } from './causal-graph-store';
 import { GraphLayout, PlanarLayout } from './graph-layout';
 import { causalGraphParser } from './parsers';
+import { isDag } from './utils';
 
 export interface UseCausalGraphEditorApi {
     api: GraphApi;
@@ -52,13 +53,16 @@ export default function useCausalGraphEditor(
     const [state, dispatch] = useReducer(
         GraphReducer,
         {
-            editorMode,
             newNodesRequirePosition,
         },
         (initState: GraphState) => {
+            const parsedGraph = causalGraphParser(graphData, availableInputs);
+            const newEditorMode = editorMode ?? (isDag(parsedGraph) ? EditorMode.DEFAULT : EditorMode.PAG_VIEWER);
+
             return {
                 ...initState,
-                graph: causalGraphParser(graphData, availableInputs),
+                graph: parsedGraph,
+                editorMode: newEditorMode,
             };
         }
     );

--- a/packages/ui-causal-graph-editor/tests/causal-graph-store.spec.tsx
+++ b/packages/ui-causal-graph-editor/tests/causal-graph-store.spec.tsx
@@ -27,6 +27,44 @@ const initialState = (): GraphState => ({
     }),
 });
 
+const dagInitialState = (): GraphState => ({
+    editorMode: EditorMode.DEFAULT,
+    graph: new Graph<SimulationNode, SimulationEdge>().import({
+        edges: [
+            {
+                attributes: {
+                    edge_type: EdgeType.DIRECTED_EDGE,
+                    originalMeta: {},
+                },
+                source: 'node1',
+                target: 'node2',
+            },
+            {
+                attributes: {
+                    edge_type: EdgeType.DIRECTED_EDGE,
+                    originalMeta: {},
+                },
+                source: 'node2',
+                target: 'node3',
+            },
+            {
+                attributes: {
+                    edge_type: EdgeType.DIRECTED_EDGE,
+                    originalMeta: {},
+                },
+                source: 'node3',
+                target: 'node1',
+            },
+        ],
+        nodes: [
+            { attributes: DEFAULT_NODE('node1'), key: 'node1' },
+            { attributes: DEFAULT_NODE('node2'), key: 'node2' },
+            { attributes: DEFAULT_NODE('node3'), key: 'node3' },
+            { attributes: DEFAULT_NODE('node4'), key: 'node4' },
+        ],
+    }),
+});
+
 const linkedState = (): GraphState => ({
     editorMode: EditorMode.DEFAULT,
     graph: new Graph<SimulationNode, SimulationEdge>().import({
@@ -78,6 +116,20 @@ describe('CausalGraphStore', () => {
             const modifiedState = initialState();
             modifiedState.graph.addEdge('node1', 'node2', DEFAULT_EDGE);
             modifiedState.editorMode = EditorMode.RESOLVER;
+
+            const state = GraphReducer(modifiedState, actions.addEdge(['node2', 'node1']));
+            expect(state.graph?.getEdgeAttribute('node2', 'node1', 'edge_type')).toEqual(EdgeType.DIRECTED_EDGE);
+        });
+        it('should add -> symbol if graph is a Dag and editor mode is undefined', () => {
+            const modifiedState = initialState();
+            modifiedState.graph.addEdge('node1', 'node2', DEFAULT_EDGE);
+
+            const state = GraphReducer(modifiedState, actions.addEdge(['node2', 'node1']));
+            expect(state.graph?.getEdgeAttribute('node2', 'node1', 'edge_type')).toEqual(EdgeType.DIRECTED_EDGE);
+        });
+        it('should add -- symbol if graph is not a Dag and editor mode is undefined', () => {
+            const modifiedState = dagInitialState();
+            modifiedState.graph.addEdge('node1', 'node4', DEFAULT_EDGE);
 
             const state = GraphReducer(modifiedState, actions.addEdge(['node2', 'node1']));
             expect(state.graph?.getEdgeAttribute('node2', 'node1', 'edge_type')).toEqual(EdgeType.DIRECTED_EDGE);


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
When an edge was added and the CausalGraphViewer did not have editorMode defined then it always added edges as undirected.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
If editorMode is not defined we check if the graph is a DAG if so we default to DEFAULT editor mode, otherwise it is set to PAG. 

This is done within the causal-graph-editor file once we have the state of the graph. However the ability to add edges is done within the reducer where this information was not yet available. 

The suggested approach was just to add the dag check within the add edge method of the reducer.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on storybook and by adding tests to cover this scenario

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->