### PR TITLE
Improvement: DO-2894 graph resizing issue

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 
 ## NEXT
 
--   `CausalGraphEditor` now only recalculates on resize of the graph window if the graph is not in focus.
+-   `CausalGraphEditor` now only recalculates its layout on resize of the graph window if the graph is not in focus.
 
 ## 1.7.4
 

--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   `CausalGraphEditor` now only recalculates on resize of the graph window if the graph is not in focus.
+
 ## 1.7.4
 
 -   Fixed an issue where if `EditorMode` was not defined edges were always added as undirected.

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -253,6 +253,7 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
         this.zoomThresholds = zoomThresholds;
         this.errorHandler = errorHandler;
         this.processEdgeStyle = processEdgeStyle;
+        this.isFocused = false;
         PIXI.Filter.defaultResolution = 3;
     }
 

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -227,6 +227,9 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
     /** whether zoom on scroll should be enabled only when the graph is focused */
     private requireFocusToZoom: boolean;
 
+    /** Whether the graph is currently focused */
+    private isFocused: boolean;
+
     constructor(
         graph: SimulationGraph,
         layout: GraphLayout,
@@ -575,7 +578,10 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
 
             // keep layout in sync - invoke a debounced update to only update it once resizing is done rather than
             // re-running a potentially expensive layout computation on every resize event
-            this.debouncedUpdateLayout();
+            // this should happen only when the graph is not currently focused
+            if (!this.isFocused) {
+                this.debouncedUpdateLayout();
+            }
         });
 
         this.resizeObserver.observe(this.container);
@@ -625,6 +631,7 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
      * @param isFocused - focus state
      */
     public setFocus(isFocused: boolean): void {
+        this.isFocused = isFocused;
         if (!this.requireFocusToZoom) {
             return;
         }


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
A user had issues with the graph recalculating layout when trying to zoom in and inspect it

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Although the cause of the issue the user experienced is not fully known as we were not able to recreate it, in the video showing the issue we see that before the resize took place scroll bars were added which would change the canvas size triggering a recalculation. With this in mind the suggested approach is that we should only resize on canvas size change if the graph is not focused. Which seems more desirable as if you are actively interacting with a graph you probably don't want it to change due to external factors.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
![resize](https://github.com/causalens/dara-ui/assets/104359539/110dbb0c-b0b8-49fb-b4d2-9c0a6c1ae733)
