### PR TITLE
Fix: DO-2780 nodes not present in tiers hangs indefinitely on jupyter

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 -   Fixed an issue where if parent hugged content `NodeHierarchyBuilder` would always scroll.
+-   Fixed an issue where `FcoseLayout` would crash when an array of array of nodes was passed to tiers which included a node that did not exist on the graph.
 
 ## 1.9.1
 

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/fcose-layout.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/fcose-layout.tsx
@@ -259,14 +259,19 @@ export function getTieredLayoutProperties(
     orientation: DirectionType,
     tierSeparation: number
 ): TiersProperties {
-    const tiersArray = getTiersArray(tiers, graph);
+    let tiersArray = getTiersArray(tiers, graph);
     let nodesOrder: Record<string, string>;
+    const nodes = graph.nodes();
 
     if (!Array.isArray(tiers)) {
         // must be of type TiersConfig
         const { order_nodes_by } = tiers;
-        const nodes = graph.nodes();
         nodesOrder = order_nodes_by ? getNodeOrder(nodes, order_nodes_by, graph) : undefined;
+    } else {
+        // if in the array of tiers passed a node present does not exist in the graph we remove it
+        tiersArray = tiersArray
+            .map((tier) => tier.filter((node) => nodes.includes(node)))
+            .filter((filteredTier) => filteredTier.length > 0);
     }
 
     return {


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
User came across an issue with CausalGraphViewer on Jupyter where it would crash when adding a nodes to the tiers array object that did not exist in their causal graph.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Although the user was using PlanarLayout, upon closer examination the layout was being defaulted to Fcose since the tiers could not be resolved. After some testing this was found to be an Fcose specific issue where since it couldn't find the node to add relative positioning to it crashed. 

The fix was for when an array of array of nodes is passed as a tier to Fcose, for us to filter it, guaranteeing that only nodes in the graph are added to the tiered positioning calculations.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->