### PR TITLE
Feat: DO-2865 causal graph viewer image download

### DIFF
--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -68,6 +68,7 @@ import useDragMode from '../shared/use-drag-mode';
 import { useEdgeConstraintEncoder } from '../shared/use-edge-encoder';
 import useIterateEdges from './utils/use-iterate-edges';
 import useIterateNodes from './utils/use-iterate-nodes';
+import { SaveImageButton } from '@shared/editor-overlay/buttons';
 
 const NotificationWrapper = styled.div`
     position: relative;
@@ -182,7 +183,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
         useEngineEvent,
         resetViewport,
         resetLayout,
-        saveImage,
+        extractImage,
         onSetDragMode,
         onNodeSelected,
         onEdgeSelected,
@@ -625,6 +626,19 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
         onSetDragMode
     );
 
+    // save image
+    const saveImage = React.useCallback(async () => {
+        const dataUrl = await extractImage();
+
+        if (dataUrl) {
+            // create a link and download the image
+            const link = document.createElement('a');
+            link.href = dataUrl;
+            link.download = 'graph.png';
+            link.click();
+        }
+    }, [extractImage]);
+
     let contentSelected = false;
     let panelTitle = '';
 
@@ -701,7 +715,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
                                     <CenterGraphButton onResetZoom={resetViewport} />
                                     <AddNodeButton onAddNode={onAddNode} />
                                     <DragModeButton dragMode={dragMode} setDragMode={setDragMode} />
-                                    <Button style={{'pointerEvents': 'all'}} styling="ghost" onClick={saveImage}>save</Button>
+                                    <SaveImageButton onSave={saveImage} />
                                 </>
                             }
                             validContentSelected={contentSelected}

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -21,7 +21,7 @@ import * as React from 'react';
 import { GetReferenceClientRect } from 'tippy.js';
 
 import styled, { useTheme } from '@darajs/styled-components';
-import { Tooltip } from '@darajs/ui-components';
+import { Button, Tooltip } from '@darajs/ui-components';
 import { Notification, NotificationPayload } from '@darajs/ui-notifications';
 import { Status, useOnClickOutside, useUpdateEffect } from '@darajs/ui-utils';
 import { ConfirmationModal } from '@darajs/ui-widgets';
@@ -182,6 +182,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
         useEngineEvent,
         resetViewport,
         resetLayout,
+        saveImage,
         onSetDragMode,
         onNodeSelected,
         onEdgeSelected,
@@ -700,6 +701,7 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
                                     <CenterGraphButton onResetZoom={resetViewport} />
                                     <AddNodeButton onAddNode={onAddNode} />
                                     <DragModeButton dragMode={dragMode} setDragMode={setDragMode} />
+                                    <Button style={{'pointerEvents': 'all'}} styling="ghost" onClick={saveImage}>save</Button>
                                 </>
                             }
                             validContentSelected={contentSelected}

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/index.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/index.tsx
@@ -19,3 +19,4 @@ export { default as CenterGraphButton } from './center-graph-button';
 export { default as DragModeButton } from './drag-mode-button';
 export { default as RecalculateLayoutButton } from './recalculate-layout-button';
 export { default as SoftEdgeArrowButton } from './soft-edge-arrow-button';
+export { default as SaveImageButton } from './save-image-button';

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/save-image-button.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/save-image-button.tsx
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2023 Impulse Innovations Limited
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useContext } from 'react';
+
+import { useTheme } from '@darajs/styled-components';
+import { Tooltip } from '@darajs/ui-components';
+import { Image } from '@darajs/ui-icons';
+
+import PointerContext from '../../pointer-context';
+import { FloatingButton } from '../floating-elements';
+
+interface SaveImageButtonProps {
+    /** Handler for saving as image */
+    onSave: () => void | Promise<void>;
+}
+
+function SaveImageButton(props: SaveImageButtonProps): JSX.Element {
+    const { disablePointerEvents } = useContext(PointerContext);
+
+    return (
+        <Tooltip content="Save as Image" placement="bottom">
+            <FloatingButton
+                aria-label="Save as Image"
+                disableEvents={disablePointerEvents}
+                fixedSize
+                onClick={props.onSave}
+                style={{ padding: '0 0.75rem' }}
+            >
+                <Image />
+            </FloatingButton>
+        </Tooltip>
+    );
+}
+
+export default SaveImageButton;

--- a/packages/ui-causal-graph-editor/src/shared/rendering/background.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/background.tsx
@@ -67,15 +67,19 @@ export class Background extends PIXI.utils.EventEmitter<'click'> {
     // eslint-disable-next-line class-methods-use-this
     private createGfx(theme: DefaultTheme): SmoothGraphics {
         const gfx = new SmoothGraphics();
-        const [color] = colorToPixi(theme.colors.grey2);
-        gfx.beginFill(color, 1, true);
+
         // we're applying scale to tileSprite, so we need to scale the distance between dots
         const distance = DOT_DISTANCE / SCALE;
+
+        // then draw the dots
+        const [color] = colorToPixi(theme.colors.grey2);
+        gfx.beginFill(color, 1, true);
         gfx.drawCircle(0, distance, 1);
         gfx.drawCircle(distance, distance, 1);
         gfx.drawCircle(0, 0, 1);
         gfx.drawCircle(distance, 0, 1);
         gfx.endFill();
+
 
         return gfx;
     }

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -663,6 +663,37 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
         event.preventDefault();
     }
 
+    public async saveToImage(): Promise<void> {
+        // create a new container to render
+        const containerWithBackground = new PIXI.Container();
+
+        // Add custom background since renderer background is not rendered
+        const bg = new PIXI.Graphics();
+        bg.beginFill(this.app.renderer.background.color, 1);
+        bg.drawRect(0, 0, this.app.renderer.width, this.app.renderer.height);
+        bg.endFill();
+        containerWithBackground.addChild(bg);
+
+        // add the stage
+        containerWithBackground.addChild(this.app.stage);
+
+        const renderTexture = this.app.renderer.generateTexture(containerWithBackground, {
+            scaleMode: PIXI.SCALE_MODES.LINEAR,
+            // multiply the resolution for better quality
+            resolution: window.devicePixelRatio * 4,
+            multisample: PIXI.MSAA_QUALITY.HIGH,
+        });
+
+        // generate the data URL
+        const dataUrl = await this.app.renderer.extract.base64(renderTexture, 'image/png');
+
+        // create a link and download the image
+        const link = document.createElement('a');
+        link.href = dataUrl;
+        link.download = 'graph.png';
+        link.click();
+    }
+
     /**
      * Update the set of constraints
      *

--- a/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
@@ -75,9 +75,9 @@ interface UseRenderEngineApi {
      */
     resetViewport: () => void;
     /**
-     * Save current canvas state as an image
+     * Get current canvas state as an image
      */
-    saveImage: () => Promise<void>;
+    extractImage: () => Promise<string>;
     /**
      * Register a handler for a given engine event.
      *
@@ -213,9 +213,9 @@ export function useRenderEngine({
                 engine.current.resetViewport();
             }
         },
-        saveImage: () => {
+        extractImage: () => {
             if (engine.current.initialized) {
-                return engine.current.saveToImage();
+                return engine.current.extractImage();
             }
         },
         useEngineEvent,

--- a/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
@@ -75,6 +75,10 @@ interface UseRenderEngineApi {
      */
     resetViewport: () => void;
     /**
+     * Save current canvas state as an image
+     */
+    saveImage: () => Promise<void>;
+    /**
      * Register a handler for a given engine event.
      *
      * @param eventName name of event to respond to
@@ -207,6 +211,11 @@ export function useRenderEngine({
         resetViewport: () => {
             if (engine.current.initialized) {
                 engine.current.resetViewport();
+            }
+        },
+        saveImage: () => {
+            if (engine.current.initialized) {
+                return engine.current.saveToImage();
             }
         },
         useEngineEvent,


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

With larger graphs, the built-in 'Save Image As' browser feature for the rendered graph canvas might unreliable, or result in blurry images as users have to zoom out to view a graph and the scaling results in low-res of the graph details.

To address the pain point, this PR implements a 'save to image' on our side which attempts to be more suitable for the common use cases. It's added as a new button in the top-right toolbar. 

One notable consequence of the approach selected (more on the possible ones in the Implementation section below) is because we go with the 'WYSIWYG' principle, if the labels or edge disappear due to low zoom level (depending on set zoom thresholds) they won't be visible on the produced image as well.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

There are mostly 3 ways such functionality could be implemented:

1. Default [`renderer.extract` Pixi APIs](https://pixijs.download/v7.2.0/docs/PIXI.CanvasExtract.html) with no arguments. The behaviour is then to take a snapshot of the visible canvas and turn it into an image, e.g. via a base64 image or creating an `<image>` tag. This is similar to effectively calling [`toDataUrl`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL) API which results in a similar low-res image as using the browser native 'save image as'. 
2. Creating a `RenderTexture` with [`renderer.generateTexture`](https://pixijs.download/v7.2.0/docs/PIXI.Renderer.html#generateTexture) and passing it to the `extract` API. This has a benefit of giving us more control over what and how we render. In this approach, we pass in the entire application stage, tweaking the resolution and other quality parameters, and generate an image similarly. This is fairly straightforward and users have a 'WYSIWYG' experience but it doesn't capture the entire graph if it's not currently in the viewport.
3. An alternative is similar to 2) but producing an alternative stage where we'd be able to always capture the graph regardless of whether it's currently visible in the viewport.

I've selected 2 as a good middleground and mostly intuitive (WYSIWYG) behaviour. 3 could be more optimal but would require a lot of extra effort for not much benefit.

I've implemented a few improvements to the approach to make it as optimal as we can:
1. Rather than capturing the entire canvas, we provide a `region` to the `extract` API to only extract the part of the viewport where the graph is. This lets us increase the resolution more and trim the empty pixels. This is particularly helpful if the graph layout becomes a rectangle with lots of 'whitespace' in one of the axes, when zoomed out.

https://github.com/causalens/dara-ui/blob/7362220530dfa965df9e81b53bf95e854e98e0be/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx#L688-L702

2. The resolution is increased to ensure that even if the graph is zoomed out, the produced image can be as detailed as possible. This is a tricky problem to balance out as increased resolution means more memory used to produce it and larger file size. To try and strike a good balance I've set up the system to aim for a 4K (3840x2160) resolution as a 'reasonable one'. Therefore the logic to pick the right resolution is roughly:
- calculate the scale multiplier for our 'region' to have the same number of pixels as a 4K image would have (since the region can have different aspect ratios we're just using total number of pixels)
- adjust the multiplier to ensure neither dimension goes over the thresholds provided by the WebGL renderer (`gl.MAX_RENDERBUFFER_SIZE` and `gl.MAX_TEXTURE_SIZE`).

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->