### PR TITLE
Fix: DO-2961 empty causal graph crashes the component

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where the GraphEditor would error if the graph was empty in some cases
+
 ## 1.9.3
 
 -   Added a new 'Save as Image' button to the graph viewer UI to download the currently displayed graph pane as a high-resolution PNG image.

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -650,7 +650,8 @@ function CausalGraphEditor({ requireFocusToZoom = true, ...props }: CausalGraphE
         panelTitle = 'Node';
     }
 
-    if (Object.keys(props.graphData?.nodes).length === 0) {
+    // if the graph is not editable and there are no nodes, there's nothing to display so show a message
+    if (!props.editable && Object.keys(props.graphData?.nodes).length === 0) {
         return (
             <Wrapper style={props.style}>
                 <Center style={{ height: 300 }}>The CausalGraph structure is empty.</Center>

--- a/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/graph-editor.stories.tsx
@@ -52,6 +52,17 @@ export default {
     title: 'CausalGraphEditor/GraphEditor',
 } as Meta;
 
+export const Empty = Template.bind({});
+Empty.args = {
+    editable: false,
+    graphData: {
+        edges: {},
+        nodes: {},
+        version: '2.0',
+    },
+    graphLayout: FcoseLayout.Builder.build(),
+};
+
 export const Interactive = (args: CausalGraphEditorProps): JSX.Element => {
     const [nodeNumber, setNodeNumber] = useState(3);
     const [useStrenghts, setUseStrengths] = useState(false);

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/fcose-layout.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/fcose-layout.tsx
@@ -335,6 +335,11 @@ export default class FcoseLayout extends GraphLayout {
         layout: LayoutMapping<XYPosition>;
     }> {
         return new Promise((resolve) => {
+            if (graph.nodes().length === 0) {
+                resolve({ layout: {} });
+                return;
+            }
+
             const hasPositions = graph.getNodeAttribute(graph.nodes()[0], 'x');
             const size = graph.getAttribute('size');
             const tiersPlacement =

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/force-atlas-layout.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/force-atlas-layout.tsx
@@ -157,6 +157,10 @@ export default class ForceAtlasLayout extends GraphLayout {
     applyLayout(graph: SimulationGraph): Promise<{
         layout: LayoutMapping<XYPosition>;
     }> {
+        if (graph.nodes().length === 0) {
+            return Promise.resolve({ layout: {} });
+        }
+
         const firstNodeAttrs = graph.getNodeAttributes(graph.nodes()[0]);
         const graphClone = graph.copy();
         const size = graphClone.getAttribute('size');

--- a/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
@@ -141,17 +141,19 @@ export function useRenderEngine({
 
     // Start engine after first render, stop it on destroy
     React.useEffect(() => {
-        engine.current.start(parentRef.current).then(() => {
-            // Attach listeners for each event type
-            ENGINE_EVENTS.forEach((eventName) => {
-                engine.current.addListener(eventName, (...args) => {
-                    listeners.current[eventName]?.apply(null, args);
+        if (parentRef.current) {
+            engine.current.start(parentRef.current).then(() => {
+                // Attach listeners for each event type
+                ENGINE_EVENTS.forEach((eventName) => {
+                    engine.current.addListener(eventName, (...args) => {
+                        listeners.current[eventName]?.apply(null, args);
+                    });
                 });
             });
-        });
+        }
 
         return () => {
-            engine.current.destroy();
+            engine.current?.destroy();
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/packages/ui-causal-graph-editor/src/shared/use-pane-visibility.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-pane-visibility.tsx
@@ -15,6 +15,10 @@ export default function usePaneVisibility(
     const isPaneVisible = React.useRef(false);
 
     React.useEffect(() => {
+        if (!pane.current) {
+            return;
+        }
+
         const observer = new IntersectionObserver((entries) => {
             for (const entry of entries) {
                 isPaneVisible.current = entry.isIntersecting;


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

This PR fixes the issue where the graph component would crash if there were no nodes in the graph.

There was a piece of rendering logic which meant that the graph canvas would not render if there were no nodes; instead, a message 'graph is empty' is displayed.

There were certain pieces of logic which made assumptions on the graph canvas being defined, these have now been fixed.

I've also adjusted the logic to display the blank canvas in editable mode - this is a valid use case as it can be used to build up the graph from scratch. I've left the message for non-editable mode as then there's no point displaying the UI. 
I'm happy to just render the blank canvas in both cases though, let me know if you think that's better.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally
Added a storybook story for the empty case

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->