### PR TITLE
Fix: DO-3044: Fix Multiselect crash when `null` is passed as `selectedItems`

### DIFF
--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -2,9 +2,13 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed a crash when `null` was passed to `MultiSelect`'s `selectedItems` prop.
+
 ## 1.9.5
 
--  Fixed an issue where select components would sometimes error out with "Maximum update depth..." React error
+-   Fixed an issue where select components would sometimes error out with "Maximum update depth..." React error
 
 ## 1.9.3
 

--- a/packages/ui-components/src/multiselect/multiselect.tsx
+++ b/packages/ui-components/src/multiselect/multiselect.tsx
@@ -263,7 +263,7 @@ function MultiSelect({ maxWidth = '100%', maxRows = 3, ...props }: MultiSelectPr
                 }
             },
             // Only set the selectedItems key if it has been explicitly set in props
-            ...('selectedItems' in props && { selectedItems: props.selectedItems }),
+            ...('selectedItems' in props && { selectedItems: props.selectedItems ?? [] }),
         });
 
     const onTermChange = useCallback(


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Fixed a crash when `null` was passed to `MultiSelect`'s `selectedItems` prop.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Downshift was handling the case when it's `undefined` correctly, but was failing when `null` was passed. Related recent change on the dara side: https://github.com/causalens/dara/pull/298.
Given that this happens to dara-ui as well, it's better to implement this change here instead of on the dara side.
Related discussion: https://github.com/causalens/dara/issues/307.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Works correctly now when passing `null`, `undefined`, `nothing`, or any element outside of the list of items.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->