### PR TITLE
Fix: DO-3116: switch component circle appears off centre on different base font

### DIFF
--- a/packages/ui-components/docs/changelog.md
+++ b/packages/ui-components/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where `Switch` appeared off centre when the base font size was changed.
+
 ## 1.9.6
 
 -   Increased performance of `Select`, `Multiselect`, `ComboBox`, `ContextMenu`, `DatepickerSelect`, `SectionedList` components in large lists by upto 485x.

--- a/packages/ui-components/src/switch/switch.tsx
+++ b/packages/ui-components/src/switch/switch.tsx
@@ -45,7 +45,7 @@ const SwitchWrapper = styled.div<EnabledProp>`
     color: ${(props) => props.theme.colors.blue1};
 
     background-color: ${(props) => (props.enabled ? props.theme.colors.primary : props.theme.colors.secondary)};
-    border-radius: 12px;
+    border-radius: 0.75rem;
 
     svg {
         color: ${(props) => props.theme.colors.blue1};
@@ -54,7 +54,7 @@ const SwitchWrapper = styled.div<EnabledProp>`
 
 const SwitchHandle = styled.span<EnabledProp>`
     position: absolute;
-    top: 2px;
+    top: 0.125rem;
     left: ${(props) => (props.enabled ? 'calc(100% - 1.375rem)' : '0.125rem')};
 
     display: inline-block;


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Switch component appeared slightly off centre when the base font was 14px instead of 16px:
![image (1)](https://github.com/causalens/dara-ui/assets/104359539/bead09ac-4594-411c-8288-e2c1fdfe3131)


## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Fixed to use `rem` instead of `px`

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally by changing the base font size to a range of different values and checking the circle kept centred

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
<img width="518" alt="Screenshot 2024-06-11 at 14 21 17" src="https://github.com/causalens/dara-ui/assets/104359539/882776b5-5972-49ff-930f-a0f9f86f3eb8">

