### PR TITLE
Fix: DO-3186 write and address uat ticket for node grouping in graph layouts

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed and issue where the nodes could escape their containers in grouping layouts.
+
 ## 1.10.0
 
 -   Added support for grouping layout in `Fcose` and `Spring` layouts. It allows for nodes to be placed on groups which can be collapsed and expanded in order to simplify graph visual structure to the user.

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -465,9 +465,9 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
                         let numberOfCollapsedEdges =
                             graphHasFinalEdge ?
                                 this.graph.getEdgeAttributes(finalSource, finalTarget)[
-                                    'meta.rendering_properties.collapsedEdgesCount'
+                                'meta.rendering_properties.collapsedEdgesCount'
                                 ]
-                            :   0;
+                                : 0;
 
                         // upddate the number of collapsed edges count if needed
                         if (graphHasFinalEdge && edgeHasChanged && group === finalSource) {
@@ -1140,9 +1140,6 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
         this.groupContainerMap.set(id, groupContainer);
 
         groupContainer.addListener('mouseover', (event: PIXI.FederatedMouseEvent) => {
-            // Always show hover state
-            this.hoverGroupContainer(id, nodes);
-
             // Only trigger the event (i.e. tooltip) if not currently dragging
             if (!this.mousedownNodeKey) {
                 this.emit('groupMouseover', event, id);
@@ -1152,9 +1149,8 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
             const local = groupContainer.groupContainerGfx.toLocal(event.global);
             const isInGroupContainer = groupContainer.groupContainerGfx.hitArea.contains(local.x, local.y);
 
-            // only trigger mouseout if it's actually outside the node (could be within label)
+            // only trigger mouseout if it's actually outside the group (could be within label)
             if (!isInGroupContainer) {
-                this.unhoverGroupContainer(id, nodes);
                 this.emit('groupMouseout', event, id);
             }
 
@@ -1339,24 +1335,6 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
         // update style
         edge.state.hover = true;
         this.updateEdgeStyleByKey(id);
-        this.requestRender();
-    }
-
-    /**
-     * Enable hover state for given group container
-     *
-     * @param id id of edge to hover
-     * @param nodes a list of simulation nodes that are part of the group
-     */
-    private hoverGroupContainer(id: string, nodes: SimulationNode[]): void {
-        const groupContainer = this.groupContainerMap.get(id);
-        if (groupContainer.state.hover) {
-            return;
-        }
-
-        // update style
-        groupContainer.state.hover = true;
-        this.updateGroupContainerStyle(id, nodes);
         this.requestRender();
     }
 
@@ -1620,24 +1598,6 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
     }
 
     /**
-     * Disable hover state for given group container
-     *
-     * @param id id of node to unhover
-     * @param nodes a list of simulation nodes that are part of the group
-     */
-    private unhoverGroupContainer(id: string, nodes: SimulationNode[]): void {
-        const groupContainer = this.groupContainerMap.get(id);
-        if (!groupContainer.state.hover) {
-            return;
-        }
-
-        // update style
-        groupContainer.state.hover = false;
-        this.updateGroupContainerStyle(id, nodes);
-        this.requestRender();
-    }
-
-    /**
      * Update edge style
      *
      * @param id id of edge to update
@@ -1814,8 +1774,8 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
     /**
      * Update style of given group container
      *
-     * @param id id of node to update
-     * @param attributes node attributes
+     * @param id id of group to update
+     * @param nodes array of nodes that are part of the group
      */
     private updateGroupContainerStyle(id: string, nodes: SimulationNode[]): void {
         const groupContainer = this.groupContainerMap.get(id);

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -465,9 +465,9 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
                         let numberOfCollapsedEdges =
                             graphHasFinalEdge ?
                                 this.graph.getEdgeAttributes(finalSource, finalTarget)[
-                                'meta.rendering_properties.collapsedEdgesCount'
+                                    'meta.rendering_properties.collapsedEdgesCount'
                                 ]
-                                : 0;
+                            :   0;
 
                         // upddate the number of collapsed edges count if needed
                         if (graphHasFinalEdge && edgeHasChanged && group === finalSource) {

--- a/packages/ui-causal-graph-editor/src/shared/rendering/grouping/definitions.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/grouping/definitions.tsx
@@ -1,7 +1,0 @@
-/**
- * Current node state
- */
-export interface GroupContainerState {
-    /** Whether an edge connected to the node is selected */
-    hover: boolean;
-}

--- a/packages/ui-causal-graph-editor/src/shared/rendering/grouping/group-container-object.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/grouping/group-container-object.tsx
@@ -24,7 +24,6 @@ import { SimulationNode } from '@types';
 
 import { TextureCache } from '../texture-cache';
 import { MOUSE_EVENTS, colorToPixi, createKey } from '../utils';
-import { GroupContainerState } from './definitions';
 
 const GROUP_RECTANGLE = 'GROUP_RECTANGLE';
 const GROUP_BORDER = 'GROUP_BORDER';
@@ -34,13 +33,6 @@ const GROUP_BORDER = 'GROUP_BORDER';
  */
 export class GroupContainerObject extends PIXI.utils.EventEmitter<(typeof MOUSE_EVENTS)[number]> {
     groupContainerGfx: PIXI.Container;
-
-    /**
-     * Current group container state
-     */
-    state: GroupContainerState = {
-        hover: false,
-    };
 
     constructor() {
         super();


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
As UAT feedback it was found that in some cased the nodes could escape their containers/groups

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Looking into it the container updated size, but as you hovered out of it, it triggered another update of style which forces it to recalculate its size. In some environments when moving too quickly it seems that this update could get old positions for the nodes and so update the container to some previous size and position. Resulting in the dragged node appearing outside of its container.

We don't actually use a hover state to draw the container. This was left over from an early stage of implementation where I wasn't sure if it would be needed. Since it is not used it has been removed.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running an app on dara side with the changes as the error did not seem to happen on storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
### Before
![before](https://github.com/causalens/dara-ui/assets/104359539/e28bc944-560c-4a19-8c2b-53567b5d524c)

### After
![after](https://github.com/causalens/dara-ui/assets/104359539/a540e4c1-4262-4235-a35f-8bd2818be42a)
