### PR TITLE
Improvement: DO-3223: Skip recalculating graph layout if size hasn't changed

### DIFF
--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 -   Reduce initial render time of `CausalGraphEditor` by `~33%` by skipping a duplicate layout calculation.
+-   Reduce update time in `useCausalGraphEditor` by another `~33%` by skipping duplicate parsing of a causal graph.
 
 ## 1.10.2
 

--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 
 ## NEXT
 
--   Reduce initial render time of CausalGraphEditor by `~33%` by skipping a duplicate layout calculation.
+-   Reduce initial render time of `CausalGraphEditor` by `~33%` by skipping a duplicate layout calculation.
 
 ## 1.10.2
 

--- a/packages/ui-causal-graph-editor/docs/changelog.md
+++ b/packages/ui-causal-graph-editor/docs/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Reduce initial render time of CausalGraphEditor by `~33%` by skipping a duplicate layout calculation.
+
 ## 1.10.2
 
 -   Fixed and issue where the nodes could escape their containers in grouping layouts.
@@ -13,7 +17,7 @@ title: Changelog
 
 ## 1.9.4
 
--   Fixed an issue where the GraphEditor would error if the graph was empty in some cases
+-   Fixed an issue where the GraphEditor would error if the graph was empty in some cases.
 
 ## 1.9.3
 

--- a/packages/ui-causal-graph-editor/src/graph-viewer/storybook/fcose.stories.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/storybook/fcose.stories.tsx
@@ -239,19 +239,32 @@ export const RandomClusters = (args: CausalGraphEditorProps): JSX.Element => {
     const [numEdges, setNumEdges] = useState(1600);
     const [numNodes, setNumNodes] = useState(800);
     const [parsedData, setParsedData] = useState<CausalGraph>();
+    const [render, setRender] = useState(false);
 
     useEffect(() => {
+        if (!render) {
+            return;
+        }
+
         const newGraph = clusters(Graph, {
             clusters: numClusters,
             order: numNodes,
             size: numEdges,
         });
         setParsedData(graphToCausalGraph(newGraph));
-    }, [numClusters, numEdges, numNodes]);
+    }, [numClusters, numEdges, numNodes, render]);
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
             <div>
+                <button
+                    onClick={() => {
+                        setNumEdges((prev) => prev + 1);
+                        setRender(true);
+                    }}
+                >
+                    Render
+                </button>
                 <span>Numer of Clusters</span>
                 <input defaultValue={numClusters} onChange={(e) => setNumClusters(e.target.valueAsNumber)} />
                 <span>Numer of Edges</span>

--- a/packages/ui-causal-graph-editor/src/graph-viewer/storybook/fcose.stories.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/storybook/fcose.stories.tsx
@@ -258,6 +258,7 @@ export const RandomClusters = (args: CausalGraphEditorProps): JSX.Element => {
         <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
             <div>
                 <button
+                    type="button"
                     onClick={() => {
                         setNumEdges((prev) => prev + 1);
                         setRender(true);

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -805,7 +805,19 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
         this.viewport.addChild(this.nodeLabelLayer);
 
         // obesrve window resizing
-        this.resizeObserver = new ResizeObserver(() => {
+        this.resizeObserver = new ResizeObserver((entries) => {
+            const oldBounds = this.graph.getAttribute('extras')?.bounds;
+            const boundsChanged = entries.some((entry) => {
+                const newBounds = entry.contentRect;
+                const newWidth = Math.round(newBounds.width);
+                const newHeight = Math.round(newBounds.height);
+                return oldBounds?.width !== newWidth || oldBounds?.height !== newHeight;
+            });
+
+            if (!boundsChanged) {
+                return;
+            }
+
             this.app.resize();
             this.viewport.resize(this.container.clientWidth, this.container.clientHeight);
             this.background.updatePosition(this.container);
@@ -1703,6 +1715,10 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
         this.onCleanup?.();
 
         try {
+            // Store the old size to avoid recalculating layout if the size hasn't changed
+            this.graph.setAttribute('extras', {
+                bounds: { width: this.container.clientWidth, height: this.container.clientHeight },
+            });
             const { layout, edgePoints, onStartDrag, onEndDrag, onCleanup, onMove, onAddNode, onAddEdge } =
                 await this.layout.applyLayout(this.graph, (l, e) => this.setLayout(l, e, false));
             this.onAddNode = onAddNode;

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -1716,9 +1716,10 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
 
         try {
             // Store the old size to avoid recalculating layout if the size hasn't changed
-            this.graph.setAttribute('extras', {
+            this.graph.updateAttribute('extras', (prev) => ({
+                ...prev,
                 bounds: { width: this.container.clientWidth, height: this.container.clientHeight },
-            });
+            }));
             const { layout, edgePoints, onStartDrag, onEndDrag, onCleanup, onMove, onAddNode, onAddEdge } =
                 await this.layout.applyLayout(this.graph, (l, e) => this.setLayout(l, e, false));
             this.onAddNode = onAddNode;

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -804,7 +804,7 @@ export class Engine extends PIXI.utils.EventEmitter<EngineEvents> {
         this.viewport.addChild(this.nodeLayer);
         this.viewport.addChild(this.nodeLabelLayer);
 
-        // obesrve window resizing
+        // Observe window resizing
         this.resizeObserver = new ResizeObserver((entries) => {
             const oldBounds = this.graph.getAttribute('extras')?.bounds;
             const boundsChanged = entries.some((entry) => {

--- a/packages/ui-causal-graph-editor/src/shared/use-causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-causal-graph-editor.tsx
@@ -112,7 +112,7 @@ export default function useCausalGraphEditor(
             const newEditorMode = editorMode ?? (isDag(parsedGraph) ? EditorMode.DEFAULT : EditorMode.PAG_VIEWER);
 
             dispatch({
-                graph: causalGraphParser(graphData, availableInputs, state.graph),
+                graph: parsedGraph,
                 editorMode: newEditorMode,
                 type: GraphActionType.INIT_GRAPH,
             });


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
1. Layout calculation was done twice for the first render due to both the original `updateLayout` calculation and a `debouncedUpdateLayout` on `ResizeObserver`. The graph now stores its previous size and only recalculates the layout if the size actually changed.
This results in ~33% reduction in first frame render time.

2. A similar issue was found in the `useCausalGraphEditor` update effect. The `causalGraphParser` was called twice. 
Just reusing the result reduced the update time by another ~33%.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Modified the random cluster story to allow profiling first frame render times.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
### First render:
BEFORE:
![image](https://github.com/causalens/dara-ui/assets/119343173/e8f320b3-b407-41de-943a-6d9260805098)
AFTER:
![image](https://github.com/causalens/dara-ui/assets/119343173/869ad686-cc42-47f7-8352-ef0ca65cb0dd)

### On graph update:
BEFORE:
![image](https://github.com/causalens/dara-ui/assets/119343173/f3d257b9-f3df-4475-93a5-3d2bf2070702)
AFTER:
![image](https://github.com/causalens/dara-ui/assets/119343173/f4708972-2e93-4944-9f44-d0b824ffcd15)


